### PR TITLE
bug 修复与微小优化

### DIFF
--- a/packages/app/src/components/prompt-kit/prompt-input.tsx
+++ b/packages/app/src/components/prompt-kit/prompt-input.tsx
@@ -101,9 +101,18 @@ function PromptInputTextarea({ className, onKeyDown, disableAutosize = false, ..
   }, [value, maxHeight, disableAutosize]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const nativeEvent = e.nativeEvent as any;
+    const isComposing = Boolean(nativeEvent?.isComposing) || nativeEvent?.keyCode === 229;
+
     if (e.key === "Enter" && !e.shiftKey) {
+      if (isComposing) {
+        onKeyDown?.(e);
+        return;
+      }
       e.preventDefault();
       onSubmit?.();
+      onKeyDown?.(e);
+      return;
     }
     onKeyDown?.(e);
   };

--- a/packages/app/src/components/side-chat/chat-input-area.tsx
+++ b/packages/app/src/components/side-chat/chat-input-area.tsx
@@ -15,7 +15,7 @@ interface ChatInputAreaProps {
 
   setInput: (value: string) => void;
   onRemoveReference: (id: string) => void;
-  onSubmit: () => void;
+  onSubmit: (promptOverride?: string) => Promise<void>;
   onStop: () => void;
   setActiveBookId: (bookId: string | undefined) => void;
 }
@@ -41,6 +41,12 @@ export function ChatInputArea({
 }: ChatInputAreaProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const isChatPage = useIsChatPage();
+  const handleQuickPrompt = (prompt: string) => {
+    setInput(prompt);
+    if (status === "ready") {
+      void onSubmit(prompt);
+    }
+  };
 
   return (
     <div className="z-10 shrink-0 px-2 pr-0 pl-1.5">
@@ -53,7 +59,7 @@ export function ChatInputArea({
                   variant="soft"
                   className="h-7 cursor-pointer"
                   size="sm"
-                  onClick={() => setInput(prompt)}
+                  onClick={() => handleQuickPrompt(prompt)}
                 >
                   <Icon className="size-4" />
                   {!showToolDetail && <span className="text-xs">{label}</span>}
@@ -68,7 +74,9 @@ export function ChatInputArea({
           isLoading={status !== "ready"}
           value={input}
           onValueChange={setInput}
-          onSubmit={onSubmit}
+          onSubmit={() => {
+            void onSubmit();
+          }}
           className="relative z-10 w-full rounded-2xl border bg-background shadow-around dark:bg-neutral-800"
         >
           {isChatPage && (
@@ -81,7 +89,7 @@ export function ChatInputArea({
                       variant="soft"
                       className="h-7 cursor-pointer"
                       size="sm"
-                      onClick={() => setInput(prompt)}
+                      onClick={() => handleQuickPrompt(prompt)}
                     >
                       <Icon className="size-4" />
                       {!showToolDetail && <span className="text-xs">{label}</span>}
@@ -140,7 +148,13 @@ export function ChatInputArea({
               type="submit"
               size="icon"
               disabled={status === "ready" ? !input.trim() : status !== "submitted" && status !== "streaming"}
-              onClick={status === "ready" ? onSubmit : onStop}
+              onClick={() => {
+                if (status === "ready") {
+                  void onSubmit();
+                } else {
+                  onStop();
+                }
+              }}
               className="size-8 rounded-full"
             >
               {status === "ready" ? (

--- a/packages/app/src/components/side-chat/index.tsx
+++ b/packages/app/src/components/side-chat/index.tsx
@@ -90,7 +90,7 @@ function ChatContent({ bookId }: ChatContentProps) {
 
   const EmptyState = () => (
     <div className="flex h-full w-full flex-col overflow-y-auto p-2 pb-8">
-      <div className="flex flex-1 flex-col justify-end gap-2">
+      <div className="flex flex-1 flex-col justify-start gap-3">
         <div className="mb-4 flex flex-col items-start gap-4 pl-2">
           <div className="rounded-full bg-muted/70 p-3 shadow-md dark:bg-neutral-800/90">
             <img className="size-8" src="https://www.notion.so/_assets/9ade71d75a1c0e93.png" alt="" />
@@ -106,7 +106,10 @@ function ChatContent({ bookId }: ChatContentProps) {
           {promptSuggestions.map(({ text, icon: Icon, isNew }) => (
             <div
               key={text}
-              onClick={() => setInput(text)}
+              onClick={() => {
+                setInput(text);
+                void handleSubmit(text);
+              }}
               className="flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 transition-colors hover:bg-muted/70 focus:outline-none focus:ring-2 focus:ring-primary/30 dark:hover:bg-neutral-800/80"
             >
               <span className="flex items-center gap-3 text-neutral-800 text-sm dark:text-neutral-200">
@@ -132,8 +135,12 @@ function ChatContent({ bookId }: ChatContentProps) {
     <main id="chat-sidebar" className="flex h-full flex-col overflow-hidden ">
       <div className="ml-1 flex-shrink-0 border-neutral-300 dark:border-neutral-700">
         <div className="flex h-8 items-center justify-between">
-          <div className="flex flex-1 items-center gap-2 pl-0.5">
-            <ModelSelector selectedModel={selectedModel} onModelSelect={setSelectedModel} className="z-40 max-w-80" />
+          <div className="flex items-center gap-2 pl-0.5">
+            <ModelSelector
+              selectedModel={selectedModel}
+              onModelSelect={setSelectedModel}
+              className="z-40 flex-shrink-0 w-[12rem]"
+            />
           </div>
           <div className="flex items-center gap-0">
             <Button

--- a/packages/app/src/components/side-chat/model-selector.tsx
+++ b/packages/app/src/components/side-chat/model-selector.tsx
@@ -103,18 +103,20 @@ export default function ModelSelector({ selectedModel, onModelSelect, className 
       <DropdownMenuTrigger asChild>
         <div
           className={cn(
-            "flex h-8 cursor-pointer select-none items-center justify-between gap-2 rounded-2xl border bg-background px-3 font-normal text-sm dark:bg-neutral-800 dark:text-neutral-200",
+            "flex h-8 w-full min-w-0 cursor-pointer select-none items-center justify-between gap-2 rounded-2xl border bg-background px-3 font-normal text-sm dark:bg-neutral-800 dark:text-neutral-200 dark:hover:border-neutral-600 overflow-hidden",
             className,
           )}
         >
-          <div className="flex items-center gap-2 truncate">
+          <div className="flex min-w-0 items-center gap-2 truncate">
             {selectedModel ? (
               <>
                 {(() => {
                   const IconComponent = getProviderIcon(selectedModel.providerId);
                   return IconComponent ? <IconComponent className="h-4 w-4 flex-shrink-0" /> : null;
                 })()}
-                <span className="truncate text-xs">{selectedModel.modelName}</span>
+                <span className="truncate text-xs" title={selectedModel.modelName}>
+                  {selectedModel.modelName}
+                </span>
               </>
             ) : (
               <span className="text-muted-foreground text-xs dark:text-neutral-400">选择模型</span>
@@ -162,8 +164,13 @@ export default function ModelSelector({ selectedModel, onModelSelect, className 
                     className="cursor-pointer p-2 dark:hover:bg-neutral-700"
                     onClick={() => handleModelSelect(model)}
                   >
-                    <div className="flex flex-col gap-1">
-                      <div className="font-medium text-xs dark:text-neutral-200">{model.modelId}</div>
+                    <div className="flex flex-col gap-1 truncate" title={model.modelName}>
+                      <div className="font-medium text-xs dark:text-neutral-200 truncate">{model.modelName}</div>
+                      {model.modelName !== model.modelId && (
+                        <div className="truncate text-[10px] text-muted-foreground dark:text-neutral-400">
+                          {model.modelId}
+                        </div>
+                      )}
                     </div>
                   </DropdownMenuItem>
                 ))}

--- a/packages/app/src/hooks/use-chat-state.ts
+++ b/packages/app/src/hooks/use-chat-state.ts
@@ -45,7 +45,7 @@ export interface UseChatStateReturn {
   handleRemoveReference: (id: string) => void;
 
   // 消息处理
-  handleSubmit: () => Promise<void>;
+  handleSubmit: (promptOverride?: string) => Promise<void>;
   handleRetry: () => Promise<void>;
 
   // 线程管理
@@ -362,10 +362,11 @@ export function useChatState(options: UseChatStateOptions): UseChatStateReturn {
     [selectedModel, setActiveContext],
   );
 
-  const handleSubmit = useCallback(async () => {
+  const handleSubmit = useCallback(async (overrideInput?: string) => {
     if (status !== "ready") return;
 
-    const trimmedInput = input.trim();
+    const sourceInput = overrideInput ?? input;
+    const trimmedInput = sourceInput.trim();
     if (!trimmedInput) return;
 
     setDisplayError(null);

--- a/packages/app/src/pages/chat/index.tsx
+++ b/packages/app/src/pages/chat/index.tsx
@@ -32,7 +32,7 @@ import { memo, useRef, useState } from "react";
 interface EmptyStateProps {
   input: string;
   setInput: (value: string) => void;
-  handleSubmit: () => void;
+  handleSubmit: (promptOverride?: string) => Promise<void>;
   stop: () => void;
   status: string;
 }
@@ -62,7 +62,9 @@ const EmptyState = memo(({ input, setInput, handleSubmit, stop, status }: EmptyS
             isLoading={status !== "ready"}
             value={input}
             onValueChange={setInput}
-            onSubmit={handleSubmit}
+            onSubmit={() => {
+              void handleSubmit();
+            }}
             className="relative z-10 w-full rounded-2xl border bg-background shadow-around dark:bg-neutral-800"
           >
             <div className="flex items-center justify-between gap-2 pt-1">
@@ -95,7 +97,7 @@ const EmptyState = memo(({ input, setInput, handleSubmit, stop, status }: EmptyS
                 onClick={(e) => {
                   e.preventDefault();
                   if (status === "ready") {
-                    handleSubmit();
+                    void handleSubmit();
                   } else {
                     stop();
                   }
@@ -118,7 +120,10 @@ const EmptyState = memo(({ input, setInput, handleSubmit, stop, status }: EmptyS
             {promptSuggestions.map(({ text, icon: Icon }) => (
               <div
                 key={text}
-                onClick={() => setInput(text)}
+                onClick={() => {
+                  setInput(text);
+                  void handleSubmit(text);
+                }}
                 className="flex w-full cursor-pointer flex-col items-start rounded-xl bg-muted p-4 transition-all dark:border-neutral-700 dark:bg-neutral-800"
               >
                 <Icon className="size-5 flex-shrink-0 text-neutral-600 dark:text-neutral-300" />


### PR DESCRIPTION
1. 修复 gemini 抓取模型失败的 bug
2. 修复当模型 ID 过长时，聊天侧栏选择框宽度过长挤占按钮位置的 bug（待优化，我觉得有更好的方案）
3. 为抓取的模型也添加“编辑”按钮，允许编辑其显示名称（编辑界面 UI 有点丑，需要你来微调了）
4. 将“总结本章”、“总结这一章的内容”等快捷按钮的逻辑改为点击即发送，不需要手动点击发送
5. 将输入框的回车逻辑微调，以适应中文输入法输入拼音或英文时，需要点击回车键时不至于直接触发发送按钮

PS：两个 index.tsx 的 commit 信息搞反了
packages/app/src/components/side-chat/index.tsx 是第二点的更改
packages/app/src/pages/chat 是第四点的更改

请别嫌弃😂