### PR TITLE
feat: 对话功能包——导出（MD/图片/HTML）、AI 命名、列表管理、辅助模型、星标

### DIFF
--- a/packages/app/src-tauri/src/core/database.rs
+++ b/packages/app/src-tauri/src/core/database.rs
@@ -43,11 +43,30 @@ pub async fn initialize(app_handle: &AppHandle) -> Result<SqlitePool, Box<dyn st
         .await?;
     println!("Database schema initialized.");
 
+    run_migrations(&pool).await?;
+
     if is_new_db {
         initialize_default_skills(&pool).await?;
     }
 
     Ok(pool)
+}
+
+/// fork 专属迁移通道：上游同步 schema.sql 时的增量变更都放这里，避免改 schema.sql 冲突。
+/// 所有迁移必须幂等。
+async fn run_migrations(pool: &SqlitePool) -> Result<(), Box<dyn std::error::Error>> {
+    // threads.starred（对话星标）：已存在时忽略 duplicate column 错误
+    let result = sqlx::query("ALTER TABLE threads ADD COLUMN starred INTEGER NOT NULL DEFAULT 0")
+        .execute(pool)
+        .await;
+
+    match result {
+        Ok(_) => println!("Migration applied: threads.starred added."),
+        Err(e) if e.to_string().contains("duplicate column name") => {}
+        Err(e) => return Err(e.into()),
+    }
+
+    Ok(())
 }
 
 async fn initialize_default_skills(pool: &SqlitePool) -> Result<(), Box<dyn std::error::Error>> {

--- a/packages/app/src-tauri/src/core/schema.sql
+++ b/packages/app/src-tauri/src/core/schema.sql
@@ -1,3 +1,4 @@
+-- 注意：threads.starred 列由 database.rs 的 fork 专属迁移添加，勿在此定义（避免与 ALTER 重复）
 CREATE TABLE IF NOT EXISTS threads (
     id TEXT PRIMARY KEY NOT NULL,
     book_id TEXT,

--- a/packages/app/src-tauri/src/core/threads/commands.rs
+++ b/packages/app/src-tauri/src/core/threads/commands.rs
@@ -39,6 +39,7 @@ pub async fn create_thread(
         metadata: payload.metadata,
         title: payload.title,
         messages: payload.messages_json,
+        starred: false,
         created_at: current_timestamp,
         updated_at: current_timestamp,
     };
@@ -56,7 +57,7 @@ pub async fn edit_thread(
     let pool = db_pool_guard.as_ref().ok_or("Database not initialized")?;
 
     let row = sqlx::query(
-        "SELECT id, book_id, metadata, title, messages, created_at, updated_at FROM threads WHERE id = ?"
+        "SELECT id, book_id, metadata, title, messages, starred, created_at, updated_at FROM threads WHERE id = ?"
     )
     .bind(&payload.id)
     .fetch_one(pool)
@@ -72,6 +73,7 @@ pub async fn edit_thread(
         metadata: row.get("metadata"),
         title: row.get("title"),
         messages: row.get("messages"),
+        starred: row.get::<i32, _>("starred") != 0,
         created_at: row.get("created_at"),
         updated_at: row.get("updated_at"),
     };
@@ -79,13 +81,15 @@ pub async fn edit_thread(
     let new_title = payload.title.unwrap_or(existing_thread.title);
     let new_metadata = payload.metadata.unwrap_or(existing_thread.metadata);
     let new_messages = payload.messages_json.unwrap_or(existing_thread.messages);
+    let new_starred = payload.starred.unwrap_or(existing_thread.starred);
 
     sqlx::query(
-        "UPDATE threads SET title = ?, metadata = ?, messages = ?, updated_at = ? WHERE id = ?",
+        "UPDATE threads SET title = ?, metadata = ?, messages = ?, starred = ?, updated_at = ? WHERE id = ?",
     )
     .bind(&new_title)
     .bind(&new_metadata)
     .bind(&new_messages)
+    .bind(if new_starred { 1 } else { 0 })
     .bind(current_timestamp)
     .bind(&payload.id)
     .execute(pool)
@@ -101,6 +105,7 @@ pub async fn edit_thread(
         metadata: new_metadata,
         title: new_title,
         messages: new_messages,
+        starred: new_starred,
         created_at: existing_thread.created_at,
         updated_at: current_timestamp,
     };
@@ -117,7 +122,7 @@ pub async fn get_latest_thread_by_book_id(
     let pool = db_pool_guard.as_ref().ok_or("Database not initialized")?;
 
     let row_result = sqlx::query(
-        "SELECT id, book_id, metadata, title, messages, created_at, updated_at FROM threads WHERE book_id IS ? ORDER BY updated_at DESC LIMIT 1"
+        "SELECT id, book_id, metadata, title, messages, starred, created_at, updated_at FROM threads WHERE book_id IS ? ORDER BY updated_at DESC LIMIT 1"
     )
     .bind(&book_id)
     .fetch_optional(pool)
@@ -134,6 +139,7 @@ pub async fn get_latest_thread_by_book_id(
             metadata: row.get("metadata"),
             title: row.get("title"),
             messages: row.get("messages"),
+            starred: row.get::<i32, _>("starred") != 0,
             created_at: row.get("created_at"),
             updated_at: row.get("updated_at"),
         };
@@ -152,7 +158,7 @@ pub async fn get_threads_by_book_id(
     let pool = db_pool_guard.as_ref().ok_or("Database not initialized")?;
 
     let rows = sqlx::query(
-        "SELECT id, book_id, metadata, title, messages, created_at, updated_at FROM threads WHERE book_id IS ? ORDER BY updated_at DESC"
+        "SELECT id, book_id, metadata, title, messages, starred, created_at, updated_at FROM threads WHERE book_id IS ? ORDER BY updated_at DESC"
     )
     .bind(&book_id)
     .fetch_all(pool)
@@ -183,6 +189,7 @@ pub async fn get_threads_by_book_id(
                 metadata: row.get("metadata"),
                 title: row.get("title"),
                 message_count,
+                starred: row.get::<i32, _>("starred") != 0,
                 created_at: row.get("created_at"),
                 updated_at: row.get("updated_at"),
             }
@@ -198,7 +205,7 @@ pub async fn get_all_threads(state: State<'_, AppState>) -> Result<Vec<ThreadSum
     let pool = db_pool_guard.as_ref().ok_or("Database not initialized")?;
 
     let rows = sqlx::query(
-        "SELECT id, book_id, metadata, title, messages, created_at, updated_at FROM threads ORDER BY updated_at DESC"
+        "SELECT id, book_id, metadata, title, messages, starred, created_at, updated_at FROM threads ORDER BY updated_at DESC"
     )
     .fetch_all(pool)
     .await
@@ -228,6 +235,7 @@ pub async fn get_all_threads(state: State<'_, AppState>) -> Result<Vec<ThreadSum
                 metadata: row.get("metadata"),
                 title: row.get("title"),
                 message_count,
+                starred: row.get::<i32, _>("starred") != 0,
                 created_at: row.get("created_at"),
                 updated_at: row.get("updated_at"),
             }
@@ -246,7 +254,7 @@ pub async fn get_thread_by_id(
     let pool = db_pool_guard.as_ref().ok_or("Database not initialized")?;
 
     let row = sqlx::query(
-        "SELECT id, book_id, metadata, title, messages, created_at, updated_at FROM threads WHERE id = ?"
+        "SELECT id, book_id, metadata, title, messages, starred, created_at, updated_at FROM threads WHERE id = ?"
     )
     .bind(&thread_id)
     .fetch_one(pool)
@@ -262,6 +270,7 @@ pub async fn get_thread_by_id(
         metadata: row.get("metadata"),
         title: row.get("title"),
         messages: row.get("messages"),
+        starred: row.get::<i32, _>("starred") != 0,
         created_at: row.get("created_at"),
         updated_at: row.get("updated_at"),
     };

--- a/packages/app/src-tauri/src/core/threads/models.rs
+++ b/packages/app/src-tauri/src/core/threads/models.rs
@@ -7,6 +7,7 @@ pub struct Thread {
     pub metadata: String,
     pub title: String,
     pub messages: String,
+    pub starred: bool,
     pub created_at: i64,
     pub updated_at: i64,
 }
@@ -18,6 +19,7 @@ pub struct ThreadSummary {
     pub metadata: String,
     pub title: String,
     pub message_count: i32,
+    pub starred: bool,
     pub created_at: i64,
     pub updated_at: i64,
 }
@@ -36,4 +38,5 @@ pub struct EditThreadPayload {
     pub title: Option<String>,
     pub metadata: Option<String>,
     pub messages_json: Option<String>,
+    pub starred: Option<bool>,
 }

--- a/packages/app/src/ai/providers/factory.ts
+++ b/packages/app/src/ai/providers/factory.ts
@@ -1,4 +1,4 @@
-import { useProviderStore } from "@/store/provider-store";
+import { type SelectedModel, useProviderStore } from "@/store/provider-store";
 import { createDeepSeek } from "@ai-sdk/deepseek";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createOpenAI } from "@ai-sdk/openai";
@@ -101,6 +101,16 @@ export function createModelInstance(providerId: string, modelId: string) {
 
   // 返回模型实例
   return providerInstance(modelId);
+}
+
+/**
+ * 获取用于轻量任务（生成对话标题、语义上下文、AI 标签等）的辅助模型
+ * 未配置辅助模型时回落到当前聊天选中模型
+ * _task 为将来按任务类型分配模型预留，当前忽略
+ */
+export function getUtilityModel(_task?: string): SelectedModel | null {
+  const { utilityModel, selectedModel } = useProviderStore.getState();
+  return utilityModel ?? selectedModel;
 }
 
 /**

--- a/packages/app/src/components/settings/providers.tsx
+++ b/packages/app/src/components/settings/providers.tsx
@@ -1,3 +1,4 @@
+import ModelSelector from "@/components/side-chat/model-selector";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
@@ -10,7 +11,7 @@ interface ProvidersSettingsProps {
 }
 
 export default function ProvidersSettings({ onProviderSelect }: ProvidersSettingsProps) {
-  const { modelProviders, setModelProviders, addProvider } = useProviderStore();
+  const { modelProviders, utilityModel, setModelProviders, setUtilityModel, addProvider } = useProviderStore();
 
   const toggleProviderEnabled = (providerId: string) => {
     const updatedProviders = modelProviders.map((provider) =>
@@ -25,7 +26,29 @@ export default function ProvidersSettings({ onProviderSelect }: ProvidersSetting
   };
 
   return (
-    <div className="p-4 pt-3">
+    <div className="space-y-4 p-4 pt-3">
+      <div className="rounded-lg bg-muted/80 p-4">
+        <h2 className="text mb-4 dark:text-neutral-200">辅助模型</h2>
+        <div className="flex items-start justify-between gap-4">
+          <p className="mt-1 text-neutral-600 text-xs dark:text-neutral-400">
+            用于生成对话标题、语义上下文、AI 标签等轻量任务，推荐选择便宜快速的模型；留空则跟随当前聊天模型
+          </p>
+          <div className="flex flex-shrink-0 items-center gap-2">
+            <ModelSelector
+              selectedModel={utilityModel}
+              onModelSelect={(model) => setUtilityModel(model)}
+              placeholder="跟随聊天模型"
+              className="w-48"
+            />
+            {utilityModel && (
+              <Button variant="ghost" size="sm" onClick={() => setUtilityModel(null)}>
+                清除
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
       <div className="rounded-lg bg-muted/80 p-4">
         <div className="flex items-center justify-between border-b pb-4">
           <h2 className="text dark:text-neutral-200">模型提供商</h2>

--- a/packages/app/src/components/side-chat/chat-messages.tsx
+++ b/packages/app/src/components/side-chat/chat-messages.tsx
@@ -6,13 +6,27 @@ import { Button } from "@/components/ui/button";
 import { useIsChatPage } from "@/hooks/use-is-chat-page";
 import { type ReasoningTimes, useReasoningTimer } from "@/hooks/use-reasoning-timer";
 import { useTextSelection } from "@/hooks/use-text-selection";
+import { exportMessagesToImage } from "@/lib/export-thread-image";
+import { exportMessageToMarkdown } from "@/lib/export-thread-markdown";
 import { cn } from "@/lib/utils";
 import { audioPlayerManager, synthesizeSpeechChunked } from "@/services/tts-service";
+import { useThreadStore } from "@/store/thread-store";
 import { useTTSStore } from "@/store/tts-store";
 import { getReasoningTimes } from "@/types/message";
 import type { UIMessage, UIMessagePart } from "ai";
 import dayjs from "dayjs";
-import { Brain, Check, Copy, Loader2, Pause, Quote, RefreshCw, Volume2 } from "lucide-react";
+import {
+  Brain,
+  Check,
+  Copy,
+  Download,
+  Image as ImageIcon,
+  Loader2,
+  Pause,
+  Quote,
+  RefreshCw,
+  Volume2,
+} from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useStickToBottomContext } from "use-stick-to-bottom";
@@ -42,6 +56,10 @@ interface ChatMessagesProps {
   canRetry?: boolean;
   onAskSelection?: (text: string) => void;
   onViewToolDetail?: (toolPart: any) => void;
+  /** 多选导出模式：显示勾选框、隐藏单条操作、整行点击切换选中 */
+  selectionMode?: boolean;
+  selectedIds?: Set<string>;
+  onToggleSelect?: (messageId: string) => void;
 }
 
 export function reorderTextAndReasoning(message: UIMessage): UIMessage {
@@ -74,6 +92,9 @@ export function ChatMessages({
   canRetry = true,
   onAskSelection,
   onViewToolDetail,
+  selectionMode = false,
+  selectedIds,
+  onToggleSelect,
 }: ChatMessagesProps) {
   const { scrollToBottom } = useStickToBottomContext();
   const isChatPage = useIsChatPage();
@@ -361,118 +382,173 @@ export function ChatMessages({
             key={message.id}
             className={cn("mx-auto flex w-full max-w-3xl flex-col items-start gap-2", isChatPage ? "px-4" : "px-2")}
           >
-            {isAssistant ? (
-              <div className="group flex w-full flex-col gap-0">
-                {renderMessageParts(reorderedMessage.parts, isLastMessage, true, message.id)}
-                {((!isStreaming && isLastMessage) || !isLastMessage) && (
-                  <div className="flex items-center justify-between">
-                    <MessageActions className="-ml-2.5 flex transform-gpu gap-0">
-                      {canShowRetry && (
-                        <MessageAction tooltip="刷新重试" delayDuration={100}>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="size-7 rounded-full"
-                            disabled={!canRetry}
-                            onClick={() => {
-                              onRetry?.();
-                            }}
-                          >
-                            <RefreshCw size={12} />
-                          </Button>
-                        </MessageAction>
-                      )}
-                      <MessageAction tooltip={copiedMessageIds.has(message.id) ? "已复制" : "复制"} delayDuration={100}>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="size-7 rounded-full"
-                          onClick={() => {
-                            const textContent = message.parts
-                              .map((part: any) => (part.type === "text" ? part.text : ""))
-                              .join("");
-                            handleCopy(message.id, textContent);
-                          }}
-                        >
-                          {copiedMessageIds.has(message.id) ? <Check size={10} /> : <Copy size={10} />}
-                        </Button>
-                      </MessageAction>
-
-                      <MessageAction
-                        tooltip={
-                          audioStates.get(message.id) === "playing"
-                            ? "暂停"
-                            : audioStates.get(message.id) === "paused"
-                              ? "继续"
-                              : "播放语音"
-                        }
-                        delayDuration={100}
-                      >
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="size-7 rounded-full"
-                          disabled={audioStates.get(message.id) === "loading"}
-                          onClick={() => {
-                            const textContent = getFilteredTextFromDOM(message.id);
-                            handlePlayAudio(message.id, textContent);
-                          }}
-                        >
-                          {audioStates.get(message.id) === "loading" ? (
-                            <Loader2 size={10} className="animate-spin" />
-                          ) : audioStates.get(message.id) === "playing" ? (
-                            <Pause size={10} />
-                          ) : (
-                            <Volume2 size={10} />
+            <div
+              className={cn("w-full", selectionMode && "flex cursor-pointer items-start gap-2")}
+              onClick={selectionMode ? () => onToggleSelect?.(message.id) : undefined}
+            >
+              {selectionMode && (
+                <div
+                  className={cn(
+                    "mt-1 flex size-4 flex-shrink-0 items-center justify-center rounded border transition-colors",
+                    selectedIds?.has(message.id)
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-neutral-400 dark:border-neutral-500",
+                  )}
+                >
+                  {selectedIds?.has(message.id) && <Check size={12} />}
+                </div>
+              )}
+              <div className={selectionMode ? "min-w-0 flex-1" : undefined}>
+                {isAssistant ? (
+                  <div className="group flex w-full flex-col gap-0">
+                    {renderMessageParts(reorderedMessage.parts, isLastMessage, true, message.id)}
+                    {((!isStreaming && isLastMessage) || !isLastMessage) && !selectionMode && (
+                      <div className="flex items-center justify-between">
+                        <MessageActions className="-ml-2.5 flex transform-gpu gap-0">
+                          {canShowRetry && (
+                            <MessageAction tooltip="刷新重试" delayDuration={100}>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="size-7 rounded-full"
+                                disabled={!canRetry}
+                                onClick={() => {
+                                  onRetry?.();
+                                }}
+                              >
+                                <RefreshCw size={12} />
+                              </Button>
+                            </MessageAction>
                           )}
-                        </Button>
-                      </MessageAction>
-                    </MessageActions>
-                    {message.metadata && (
-                      <div className="flex items-center gap-2 text-neutral-500 text-xs dark:text-neutral-400">
-                        {message.metadata.totalUsage && (
-                          <span className="text-xs">{message.metadata.totalUsage.totalTokens} tokens</span>
-                        )}
-                        {message.metadata.updatedAt && (
-                          <span className="text-xs">
-                            {dayjs(message.metadata.updatedAt * 1000).format("YYYY-MM-DD HH:mm:ss")}
-                          </span>
+                          <MessageAction
+                            tooltip={copiedMessageIds.has(message.id) ? "已复制" : "复制"}
+                            delayDuration={100}
+                          >
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="size-7 rounded-full"
+                              onClick={() => {
+                                const textContent = message.parts
+                                  .map((part: any) => (part.type === "text" ? part.text : ""))
+                                  .join("");
+                                handleCopy(message.id, textContent);
+                              }}
+                            >
+                              {copiedMessageIds.has(message.id) ? <Check size={10} /> : <Copy size={10} />}
+                            </Button>
+                          </MessageAction>
+
+                          <MessageAction tooltip="导出为 Markdown" delayDuration={100}>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="size-7 rounded-full"
+                              onClick={() => {
+                                void exportMessageToMarkdown(message, {
+                                  threadTitle: useThreadStore.getState().currentThread?.title,
+                                  index,
+                                });
+                              }}
+                            >
+                              <Download size={10} />
+                            </Button>
+                          </MessageAction>
+
+                          <MessageAction tooltip="导出为图片" delayDuration={100}>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="size-7 rounded-full"
+                              onClick={() => {
+                                const { currentThread } = useThreadStore.getState();
+                                void exportMessagesToImage([message], {
+                                  title: `${currentThread?.title || "未命名对话"}-第${index + 1}条`,
+                                  bookId: currentThread?.book_id,
+                                  successText: "消息导出成功",
+                                });
+                              }}
+                            >
+                              <ImageIcon size={10} />
+                            </Button>
+                          </MessageAction>
+
+                          <MessageAction
+                            tooltip={
+                              audioStates.get(message.id) === "playing"
+                                ? "暂停"
+                                : audioStates.get(message.id) === "paused"
+                                  ? "继续"
+                                  : "播放语音"
+                            }
+                            delayDuration={100}
+                          >
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="size-7 rounded-full"
+                              disabled={audioStates.get(message.id) === "loading"}
+                              onClick={() => {
+                                const textContent = getFilteredTextFromDOM(message.id);
+                                handlePlayAudio(message.id, textContent);
+                              }}
+                            >
+                              {audioStates.get(message.id) === "loading" ? (
+                                <Loader2 size={10} className="animate-spin" />
+                              ) : audioStates.get(message.id) === "playing" ? (
+                                <Pause size={10} />
+                              ) : (
+                                <Volume2 size={10} />
+                              )}
+                            </Button>
+                          </MessageAction>
+                        </MessageActions>
+                        {message.metadata && (
+                          <div className="flex items-center gap-2 text-neutral-500 text-xs dark:text-neutral-400">
+                            {message.metadata.totalUsage && (
+                              <span className="text-xs">{message.metadata.totalUsage.totalTokens} tokens</span>
+                            )}
+                            {message.metadata.updatedAt && (
+                              <span className="text-xs">
+                                {dayjs(message.metadata.updatedAt * 1000).format("YYYY-MM-DD HH:mm:ss")}
+                              </span>
+                            )}
+                          </div>
                         )}
                       </div>
                     )}
+                    {showError && (
+                      <div className="mt-2 w-full rounded-lg border border-red-200 bg-red-50 p-3 text-red-800 text-xs dark:border-red-800 dark:bg-red-900/20 dark:text-red-200">
+                        错误: {errorMessage}
+                      </div>
+                    )}
                   </div>
-                )}
-                {showError && (
-                  <div className="mt-2 w-full rounded-lg border border-red-200 bg-red-50 p-3 text-red-800 text-xs dark:border-red-800 dark:bg-red-900/20 dark:text-red-200">
-                    错误: {errorMessage}
-                  </div>
-                )}
-              </div>
-            ) : (
-              <div className={cn("group mt-7 flex max-w-full flex-col", isFirstMessage && "mt-0")}>
-                {renderMessageParts(reorderedMessage.parts, isLastMessage, false, message.id)}
+                ) : (
+                  <div className={cn("group mt-7 flex max-w-full flex-col", isFirstMessage && "mt-0")}>
+                    {renderMessageParts(reorderedMessage.parts, isLastMessage, false, message.id)}
 
-                <MessageActions
-                  className={cn(
-                    "flex transform-gpu justify-end gap-0 opacity-0 transition-opacity duration-150 group-hover:opacity-100",
-                  )}
-                >
-                  {canShowRetry && (
-                    <MessageAction tooltip="刷新重试" delayDuration={100}>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="size-7 rounded-full hover:bg-white dark:hover:bg-neutral-600"
-                        disabled={!canRetry}
-                        onClick={() => {
-                          onRetry?.();
-                        }}
+                    {!selectionMode && (
+                      <MessageActions
+                        className={cn(
+                          "flex transform-gpu justify-end gap-0 opacity-0 transition-opacity duration-150 group-hover:opacity-100",
+                        )}
                       >
-                        <RefreshCw size={12} />
-                      </Button>
-                    </MessageAction>
-                  )}
-                  {/* TODO: 实现编辑功能
+                        {canShowRetry && (
+                          <MessageAction tooltip="刷新重试" delayDuration={100}>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="size-7 rounded-full hover:bg-white dark:hover:bg-neutral-600"
+                              disabled={!canRetry}
+                              onClick={() => {
+                                onRetry?.();
+                              }}
+                            >
+                              <RefreshCw size={12} />
+                            </Button>
+                          </MessageAction>
+                        )}
+                        {/* TODO: 实现编辑功能
                   <MessageAction tooltip="编辑" delayDuration={100}>
                     <Button
                       variant="ghost"
@@ -483,7 +559,7 @@ export function ChatMessages({
                     </Button>
                   </MessageAction>
                   */}
-                  {/* TODO: 实现删除功能
+                        {/* TODO: 实现删除功能
                   <MessageAction tooltip="删除" delayDuration={100}>
                     <Button
                       variant="ghost"
@@ -494,29 +570,67 @@ export function ChatMessages({
                     </Button>
                   </MessageAction>
                   */}
-                  <MessageAction tooltip={copiedMessageIds.has(message.id) ? "已复制" : "复制"} delayDuration={100}>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="size-7 rounded-full hover:bg-white dark:hover:bg-neutral-600"
-                      onClick={() => {
-                        const textContent = reorderedMessage.parts
-                          .map((part: any) => (part.type === "text" ? part.text : ""))
-                          .join("");
-                        handleCopy(message.id, textContent);
-                      }}
-                    >
-                      {copiedMessageIds.has(message.id) ? <Check size={12} /> : <Copy size={12} />}
-                    </Button>
-                  </MessageAction>
-                </MessageActions>
-                {showError && (
-                  <div className="mt-2 max-w-full rounded-lg border border-red-200 bg-red-50 px-1.5 py-1 text-red-800 text-sm dark:border-red-800 dark:bg-red-900/20 dark:text-red-200">
-                    {errorMessage}
+                        <MessageAction
+                          tooltip={copiedMessageIds.has(message.id) ? "已复制" : "复制"}
+                          delayDuration={100}
+                        >
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="size-7 rounded-full hover:bg-white dark:hover:bg-neutral-600"
+                            onClick={() => {
+                              const textContent = reorderedMessage.parts
+                                .map((part: any) => (part.type === "text" ? part.text : ""))
+                                .join("");
+                              handleCopy(message.id, textContent);
+                            }}
+                          >
+                            {copiedMessageIds.has(message.id) ? <Check size={12} /> : <Copy size={12} />}
+                          </Button>
+                        </MessageAction>
+                        <MessageAction tooltip="导出为 Markdown" delayDuration={100}>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="size-7 rounded-full hover:bg-white dark:hover:bg-neutral-600"
+                            onClick={() => {
+                              void exportMessageToMarkdown(message, {
+                                threadTitle: useThreadStore.getState().currentThread?.title,
+                                index,
+                              });
+                            }}
+                          >
+                            <Download size={12} />
+                          </Button>
+                        </MessageAction>
+                        <MessageAction tooltip="导出为图片" delayDuration={100}>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="size-7 rounded-full hover:bg-white dark:hover:bg-neutral-600"
+                            onClick={() => {
+                              const { currentThread } = useThreadStore.getState();
+                              void exportMessagesToImage([message], {
+                                title: `${currentThread?.title || "未命名对话"}-第${index + 1}条`,
+                                bookId: currentThread?.book_id,
+                                successText: "消息导出成功",
+                              });
+                            }}
+                          >
+                            <ImageIcon size={12} />
+                          </Button>
+                        </MessageAction>
+                      </MessageActions>
+                    )}
+                    {showError && (
+                      <div className="mt-2 max-w-full rounded-lg border border-red-200 bg-red-50 px-1.5 py-1 text-red-800 text-sm dark:border-red-800 dark:bg-red-900/20 dark:text-red-200">
+                        {errorMessage}
+                      </div>
+                    )}
                   </div>
                 )}
               </div>
-            )}
+            </div>
           </Message>
         );
       })}

--- a/packages/app/src/components/side-chat/chat-threads.tsx
+++ b/packages/app/src/components/side-chat/chat-threads.tsx
@@ -36,11 +36,7 @@ export function ChatThreads({ bookId, onBack, onSelectThread }: ChatThreadsProps
   const [renameTitle, setRenameTitle] = useState("");
   const [isRenaming, setIsRenaming] = useState(false);
 
-  // 星标对话排在前面，其余保持原顺序（sort 稳定）
-  const sortedThreads = useMemo(
-    () => [...threads].sort((a, b) => Number(b.starred ?? false) - Number(a.starred ?? false)),
-    [threads],
-  );
+  const sortedThreads = threads;
 
   const handleNativeDelete = useCallback(
     async (thread: ThreadSummary) => {

--- a/packages/app/src/components/side-chat/chat-threads.tsx
+++ b/packages/app/src/components/side-chat/chat-threads.tsx
@@ -11,8 +11,8 @@ import { Menu } from "@tauri-apps/api/menu";
 import { LogicalPosition } from "@tauri-apps/api/window";
 import { ask } from "@tauri-apps/plugin-dialog";
 import dayjs from "dayjs";
-import { ArrowLeft, MessageCircle } from "lucide-react";
-import { useCallback, useState } from "react";
+import { ArrowLeft, MessageCircle, Star } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 interface ChatThreadsProps {
@@ -29,11 +29,18 @@ export function ChatThreads({ bookId, onBack, onSelectThread }: ChatThreadsProps
     handleDeleteThread: deleteThreadFn,
     handleRenameThread: renameThreadFn,
     handleAiRenameThread: aiRenameThreadFn,
+    handleToggleStar: toggleStarFn,
   } = useThreads({ bookId });
 
   const [renameTarget, setRenameTarget] = useState<ThreadSummary | null>(null);
   const [renameTitle, setRenameTitle] = useState("");
   const [isRenaming, setIsRenaming] = useState(false);
+
+  // 星标对话排在前面，其余保持原顺序（sort 稳定）
+  const sortedThreads = useMemo(
+    () => [...threads].sort((a, b) => Number(b.starred ?? false) - Number(a.starred ?? false)),
+    [threads],
+  );
 
   const handleNativeDelete = useCallback(
     async (thread: ThreadSummary) => {
@@ -266,17 +273,33 @@ export function ChatThreads({ bookId, onBack, onSelectThread }: ChatThreadsProps
           </div>
         ) : (
           <div className="space-y-2">
-            {threads.map((thread) => (
+            {sortedThreads.map((thread) => (
               <button
                 key={thread.id}
                 onClick={() => onSelectThread(thread)}
                 onContextMenu={handleMenuClick(thread)}
-                className="w-full cursor-pointer rounded-lg border p-2 text-left"
+                className="group w-full cursor-pointer rounded-lg border p-2 text-left"
               >
                 <div className="mb-1 flex items-start justify-between gap-2">
                   <h3 className="line-clamp-1 flex-1 font-medium text-neutral-900 text-sm dark:text-neutral-100">
                     {thread.title || "未命名对话"}
                   </h3>
+                  <span
+                    role="button"
+                    tabIndex={-1}
+                    title={thread.starred ? "取消星标" : "星标"}
+                    className={`flex-shrink-0 cursor-pointer opacity-40 transition-opacity hover:opacity-100 group-hover:opacity-70 ${
+                      thread.starred ? "opacity-100" : ""
+                    }`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      void toggleStarFn(thread);
+                    }}
+                  >
+                    <Star
+                      className={`size-3.5 ${thread.starred ? "fill-amber-400 text-amber-400" : "text-neutral-400"}`}
+                    />
+                  </span>
                 </div>
                 <div className="flex items-center justify-between gap-2">
                   <span className="text-neutral-600 text-xs dark:text-neutral-400">{thread.message_count} 条消息</span>

--- a/packages/app/src/components/side-chat/chat-threads.tsx
+++ b/packages/app/src/components/side-chat/chat-threads.tsx
@@ -2,6 +2,8 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { useThreads } from "@/hooks/use-threads";
+import { exportThreadToHtml } from "@/lib/export-thread-html";
+import { exportThreadToImage } from "@/lib/export-thread-image";
 import { exportThreadToMarkdown } from "@/lib/export-thread-markdown";
 import { getThreadById } from "@/services/thread-service";
 import type { ThreadSummary } from "@/types/thread";
@@ -86,6 +88,26 @@ export function ChatThreads({ bookId, onBack, onSelectThread }: ChatThreadsProps
     }
   }, []);
 
+  const handleExportHtml = useCallback(async (thread: ThreadSummary) => {
+    try {
+      const fullThread = await getThreadById(thread.id);
+      await exportThreadToHtml(fullThread);
+    } catch (error) {
+      console.error("导出对话失败:", error);
+      toast.error("导出对话失败");
+    }
+  }, []);
+
+  const handleExportImage = useCallback(async (thread: ThreadSummary) => {
+    try {
+      const fullThread = await getThreadById(thread.id);
+      await exportThreadToImage(fullThread);
+    } catch (error) {
+      console.error("导出对话失败:", error);
+      toast.error("导出对话失败");
+    }
+  }, []);
+
   const handleAiRename = useCallback(
     (thread: ThreadSummary) => {
       if (!thread.message_count) {
@@ -127,6 +149,20 @@ export function ChatThreads({ bookId, onBack, onSelectThread }: ChatThreadsProps
               },
             },
             {
+              id: "export-html",
+              text: "导出为 HTML",
+              action: () => {
+                handleExportHtml(thread);
+              },
+            },
+            {
+              id: "export-image",
+              text: "导出为图片",
+              action: () => {
+                handleExportImage(thread);
+              },
+            },
+            {
               id: "delete",
               text: "删除",
               action: () => {
@@ -141,7 +177,7 @@ export function ChatThreads({ bookId, onBack, onSelectThread }: ChatThreadsProps
         console.error("显示菜单失败:", error);
       }
     },
-    [handleNativeDelete, handleOpenRename, handleExportThread, handleAiRename],
+    [handleNativeDelete, handleOpenRename, handleExportThread, handleExportHtml, handleExportImage, handleAiRename],
   );
 
   if (status === "pending") {

--- a/packages/app/src/components/side-chat/chat-threads.tsx
+++ b/packages/app/src/components/side-chat/chat-threads.tsx
@@ -1,12 +1,17 @@
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import { useThreads } from "@/hooks/use-threads";
+import { exportThreadToMarkdown } from "@/lib/export-thread-markdown";
+import { getThreadById } from "@/services/thread-service";
 import type { ThreadSummary } from "@/types/thread";
 import { Menu } from "@tauri-apps/api/menu";
 import { LogicalPosition } from "@tauri-apps/api/window";
 import { ask } from "@tauri-apps/plugin-dialog";
 import dayjs from "dayjs";
 import { ArrowLeft, MessageCircle } from "lucide-react";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
 
 interface ChatThreadsProps {
   bookId: string | undefined;
@@ -15,7 +20,18 @@ interface ChatThreadsProps {
 }
 
 export function ChatThreads({ bookId, onBack, onSelectThread }: ChatThreadsProps) {
-  const { threads, error, status, handleDeleteThread: deleteThreadFn } = useThreads({ bookId });
+  const {
+    threads,
+    error,
+    status,
+    handleDeleteThread: deleteThreadFn,
+    handleRenameThread: renameThreadFn,
+    handleAiRenameThread: aiRenameThreadFn,
+  } = useThreads({ bookId });
+
+  const [renameTarget, setRenameTarget] = useState<ThreadSummary | null>(null);
+  const [renameTitle, setRenameTitle] = useState("");
+  const [isRenaming, setIsRenaming] = useState(false);
 
   const handleNativeDelete = useCallback(
     async (thread: ThreadSummary) => {
@@ -35,6 +51,52 @@ export function ChatThreads({ bookId, onBack, onSelectThread }: ChatThreadsProps
     [deleteThreadFn],
   );
 
+  const handleOpenRename = useCallback((thread: ThreadSummary) => {
+    setRenameTitle(thread.title || "");
+    setRenameTarget(thread);
+  }, []);
+
+  const handleConfirmRename = useCallback(async () => {
+    if (!renameTarget) return;
+
+    const title = renameTitle.trim();
+    if (!title) {
+      toast.error("标题不能为空");
+      return;
+    }
+
+    setIsRenaming(true);
+    try {
+      await renameThreadFn(renameTarget.id, title);
+      setRenameTarget(null);
+    } catch {
+      // 失败提示已在 useThreads 中处理
+    } finally {
+      setIsRenaming(false);
+    }
+  }, [renameTarget, renameTitle, renameThreadFn]);
+
+  const handleExportThread = useCallback(async (thread: ThreadSummary) => {
+    try {
+      const fullThread = await getThreadById(thread.id);
+      await exportThreadToMarkdown(fullThread);
+    } catch (error) {
+      console.error("导出对话失败:", error);
+      toast.error("导出对话失败");
+    }
+  }, []);
+
+  const handleAiRename = useCallback(
+    (thread: ThreadSummary) => {
+      if (!thread.message_count) {
+        toast.error("对话为空，无法生成标题");
+        return;
+      }
+      aiRenameThreadFn(thread.id);
+    },
+    [aiRenameThreadFn],
+  );
+
   const handleMenuClick = useCallback(
     (thread: ThreadSummary) => async (menuEvent: React.MouseEvent) => {
       menuEvent.preventDefault();
@@ -43,6 +105,27 @@ export function ChatThreads({ bookId, onBack, onSelectThread }: ChatThreadsProps
       try {
         const menu = await Menu.new({
           items: [
+            {
+              id: "rename",
+              text: "重命名",
+              action: () => {
+                handleOpenRename(thread);
+              },
+            },
+            {
+              id: "ai-rename",
+              text: "AI 重命名",
+              action: () => {
+                handleAiRename(thread);
+              },
+            },
+            {
+              id: "export-markdown",
+              text: "导出为 Markdown",
+              action: () => {
+                handleExportThread(thread);
+              },
+            },
             {
               id: "delete",
               text: "删除",
@@ -58,7 +141,7 @@ export function ChatThreads({ bookId, onBack, onSelectThread }: ChatThreadsProps
         console.error("显示菜单失败:", error);
       }
     },
-    [handleNativeDelete],
+    [handleNativeDelete, handleOpenRename, handleExportThread, handleAiRename],
   );
 
   if (status === "pending") {
@@ -170,6 +253,44 @@ export function ChatThreads({ bookId, onBack, onSelectThread }: ChatThreadsProps
           </div>
         )}
       </div>
+
+      <Dialog
+        open={!!renameTarget}
+        onOpenChange={(open) => {
+          if (!open && !isRenaming) {
+            setRenameTarget(null);
+          }
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>重命名对话</DialogTitle>
+          </DialogHeader>
+          <div className="flex flex-col gap-4 p-4">
+            <Input
+              value={renameTitle}
+              onChange={(e) => setRenameTitle(e.target.value)}
+              placeholder="输入新的对话标题"
+              maxLength={50}
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !isRenaming) {
+                  e.preventDefault();
+                  handleConfirmRename();
+                }
+              }}
+            />
+            <div className="flex justify-end gap-3">
+              <Button variant="outline" onClick={() => setRenameTarget(null)} disabled={isRenaming}>
+                取消
+              </Button>
+              <Button onClick={handleConfirmRename} disabled={isRenaming || !renameTitle.trim()} className="min-w-24">
+                {isRenaming ? "保存中..." : "确定"}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/packages/app/src/components/side-chat/index.tsx
+++ b/packages/app/src/components/side-chat/index.tsx
@@ -1,6 +1,9 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useChatState } from "@/hooks/use-chat-state";
+import { exportMessagesToHtml } from "@/lib/export-thread-html";
+import { exportMessagesToImage } from "@/lib/export-thread-image";
+import { exportMessagesToMarkdown } from "@/lib/export-thread-markdown";
 import { useReaderStore } from "@/pages/reader/components/reader-provider";
 import { useAppSettingsStore } from "@/store/app-settings-store";
 import { useThemeStore } from "@/store/theme-store";
@@ -8,6 +11,7 @@ import {
   CircleQuestionMark,
   History,
   Lightbulb,
+  ListChecks,
   MessageCirclePlus,
   NotebookPen,
   ScrollText,
@@ -15,7 +19,7 @@ import {
   Settings,
   UserSearch,
 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ChatContainerRoot } from "../prompt-kit/chat-container";
 import { ScrollButton } from "../prompt-kit/scroll-button";
 import { MindmapDialog } from "../tools/mindmap-dialog";
@@ -33,6 +37,9 @@ function ChatContent({ bookId }: ChatContentProps) {
   const { autoScroll } = useThemeStore();
   const [toolDetail, setToolDetail] = useState<any>(null);
   const [showMindmapDialog, setShowMindmapDialog] = useState(false);
+  // 多选导出：组件内状态，切换对话自动退出
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const setActiveContext = useReaderStore((state) => state.setActiveContext)!;
   const progress = useReaderStore((state) => state.progress);
   const activeContext = useReaderStore((state) => state.activeContext)!;
@@ -78,6 +85,50 @@ function ChatContent({ bookId }: ChatContentProps) {
     setToolDetail(toolPart);
     setShowMindmapDialog(true);
   };
+
+  // 多选导出
+  const exitSelectionMode = () => {
+    setSelectionMode(false);
+    setSelectedIds(new Set());
+  };
+
+  const handleToggleSelect = (messageId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(messageId)) {
+        next.delete(messageId);
+      } else {
+        next.add(messageId);
+      }
+      return next;
+    });
+  };
+
+  const getSelectedMessages = () => messages.filter((m) => selectedIds.has(m.id));
+
+  const buildSelectionMeta = () => ({
+    title: `${currentThread?.title || "未命名对话"}-节选`,
+    bookId: currentThread?.book_id ?? bookId ?? null,
+  });
+
+  // 切换对话时退出选择模式
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+  useEffect(() => {
+    exitSelectionMode();
+  }, [currentThread?.id]);
+
+  // Esc 退出选择模式
+  useEffect(() => {
+    if (!selectionMode) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setSelectionMode(false);
+        setSelectedIds(new Set());
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [selectionMode]);
 
   const promptSuggestions = [
     { text: "总结这一页的内容", icon: ScrollText, isNew: true },
@@ -132,7 +183,7 @@ function ChatContent({ bookId }: ChatContentProps) {
   );
 
   return (
-    <main id="chat-sidebar" className="flex h-full flex-col overflow-hidden ">
+    <main id="chat-sidebar" className="relative flex h-full flex-col overflow-hidden ">
       <div className="ml-1 flex-shrink-0 border-neutral-300 dark:border-neutral-700">
         <div className="flex h-8 items-center justify-between">
           <div className="flex items-center gap-2 pl-0.5">
@@ -143,6 +194,19 @@ function ChatContent({ bookId }: ChatContentProps) {
             />
           </div>
           <div className="flex items-center gap-0">
+            {messages.length > 0 && !showThreads && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className={`z-40 size-7 rounded-full hover:bg-neutral-200 dark:hover:bg-neutral-700 ${
+                  selectionMode ? "bg-neutral-200 dark:bg-neutral-700" : ""
+                }`}
+                title="选择导出"
+                onClick={() => (selectionMode ? exitSelectionMode() : setSelectionMode(true))}
+              >
+                <ListChecks className="h-5 w-5" />
+              </Button>
+            )}
             <Button
               variant="ghost"
               size="icon"
@@ -192,6 +256,9 @@ function ChatContent({ bookId }: ChatContentProps) {
             canRetry={status === "ready" && !!displayError}
             onAskSelection={handleAskSelection}
             onViewToolDetail={handleViewToolDetail}
+            selectionMode={selectionMode}
+            selectedIds={selectedIds}
+            onToggleSelect={handleToggleSelect}
           />
           <div className="-translate-x-1/2 pointer-events-none absolute bottom-4 left-1/2 flex w-full max-w-3xl justify-end px-5">
             <div className="pointer-events-auto">
@@ -199,6 +266,39 @@ function ChatContent({ bookId }: ChatContentProps) {
             </div>
           </div>
         </ChatContainerRoot>
+      )}
+
+      {selectionMode && !showThreads && (
+        <div className="-translate-x-1/2 absolute bottom-20 left-1/2 z-40 flex items-center gap-2 rounded-xl border bg-background px-3 py-2 shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
+          <span className="text-neutral-600 text-xs dark:text-neutral-400">已选 {selectedIds.size} 条</span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={selectedIds.size === 0}
+            onClick={() => void exportMessagesToMarkdown(getSelectedMessages(), buildSelectionMeta())}
+          >
+            Markdown
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={selectedIds.size === 0}
+            onClick={() => void exportMessagesToHtml(getSelectedMessages(), buildSelectionMeta())}
+          >
+            HTML
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={selectedIds.size === 0}
+            onClick={() => void exportMessagesToImage(getSelectedMessages(), buildSelectionMeta())}
+          >
+            图片
+          </Button>
+          <Button variant="ghost" size="sm" onClick={exitSelectionMode}>
+            取消
+          </Button>
+        </div>
       )}
 
       {!showThreads && bookId && (

--- a/packages/app/src/components/side-chat/model-selector.tsx
+++ b/packages/app/src/components/side-chat/model-selector.tsx
@@ -26,9 +26,15 @@ interface ModelSelectorProps {
   selectedModel: SelectedModel | null;
   onModelSelect: (model: SelectedModel) => void;
   className?: string;
+  placeholder?: string;
 }
 
-export default function ModelSelector({ selectedModel, onModelSelect, className }: ModelSelectorProps) {
+export default function ModelSelector({
+  selectedModel,
+  onModelSelect,
+  className,
+  placeholder = "选择模型",
+}: ModelSelectorProps) {
   const { modelProviders } = useProviderStore();
   const [searchTerm, setSearchTerm] = useState("");
   const [open, setOpen] = useState(false);
@@ -119,7 +125,7 @@ export default function ModelSelector({ selectedModel, onModelSelect, className 
                 </span>
               </>
             ) : (
-              <span className="text-muted-foreground text-xs dark:text-neutral-400">选择模型</span>
+              <span className="text-muted-foreground text-xs dark:text-neutral-400">{placeholder}</span>
             )}
           </div>
           <ChevronDown className="h-3 w-3 flex-shrink-0" />

--- a/packages/app/src/hooks/use-chat-state.ts
+++ b/packages/app/src/hooks/use-chat-state.ts
@@ -93,6 +93,12 @@ export function useChatState(options: UseChatStateOptions): UseChatStateReturn {
   const messagesRef = useRef<UIMessage[]>([]);
   const reasoningTimesRef = useRef<{ [messageId: string]: ReasoningTimes }>({});
 
+  // 异步回调（onFinish 等）里要读最新的 currentThread，且来源必须与调用方一致（options 优先）
+  const currentThreadRef = useRef(currentThread);
+  useEffect(() => {
+    currentThreadRef.current = currentThread;
+  }, [currentThread]);
+
   const handleReasoningTimesUpdate = (messageId: string, reasoningTimes: ReasoningTimes) => {
     reasoningTimesRef.current[messageId] = reasoningTimes;
   };
@@ -109,7 +115,7 @@ export function useChatState(options: UseChatStateOptions): UseChatStateReturn {
         console.error("Error:", error);
       },
       onFinish: ({ message, messages: finishedMessages, isError }) => {
-        const { currentThread } = useThreadStore.getState();
+        const currentThread = currentThreadRef.current;
         const { selectedModel } = useProviderStore.getState();
         const resolvedMessages = finishedMessages ?? messagesRef.current;
 
@@ -358,8 +364,7 @@ export function useChatState(options: UseChatStateOptions): UseChatStateReturn {
   const generateSemanticContextAsync = useCallback(
     async (userQuestion: string) => {
       try {
-        const { currentThread } = useThreadStore.getState();
-        const thread = currentThread;
+        const thread = currentThreadRef.current;
         if (!thread) {
           console.log("No current thread, skipping context generation");
           return;

--- a/packages/app/src/hooks/use-chat-state.ts
+++ b/packages/app/src/hooks/use-chat-state.ts
@@ -12,10 +12,12 @@ import {
   getThreadContext,
   updateThreadContext,
 } from "@/services/thread-service";
+import { generateThreadTitleWithAI } from "@/services/thread-title-service";
 import { type SelectedModel, useProviderStore } from "@/store/provider-store";
 import { useThreadStore } from "@/store/thread-store";
 import type { ChatReference, MessageMetadata } from "@/types/message";
 import type { Thread, ThreadSummary } from "@/types/thread";
+import { useQueryClient } from "@tanstack/react-query";
 import type { UIMessage } from "ai";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -86,6 +88,7 @@ export function useChatState(options: UseChatStateOptions): UseChatStateReturn {
   const currentThread = options.currentThread !== undefined ? options.currentThread : globalThreadStore.currentThread;
   const setCurrentThread = options.setCurrentThread || globalThreadStore.setCurrentThread;
   const forceUpdate = useForceUpdate();
+  const queryClient = useQueryClient();
 
   const messagesRef = useRef<UIMessage[]>([]);
   const reasoningTimesRef = useRef<{ [messageId: string]: ReasoningTimes }>({});
@@ -155,11 +158,38 @@ export function useChatState(options: UseChatStateOptions): UseChatStateReturn {
           return;
         }
 
+        // 首轮问答完成后，若标题仍是占位标题（首条消息截断或"新对话"），用 AI 异步生成简短标题
+        const autoNameFirstRound = (thread: Thread) => {
+          const userMessages = normalizedMessages.filter((m) => m.role === "user");
+          const assistantMessages = normalizedMessages.filter((m) => m.role === "assistant");
+          if (userMessages.length !== 1 || assistantMessages.length !== 1) return;
+
+          const firstUserParts = userMessages[0]?.parts ?? [];
+          const firstUserText = firstUserParts.map((p: any) => (p.type === "text" ? p.text : "")).join("");
+          const firstQuoteText = (firstUserParts.find((p: any) => p.type === "quote") as any)?.text || "";
+          const placeholderTitle = (firstUserText || firstQuoteText || "新对话").slice(0, 50);
+          const isPlaceholderTitle = !thread.title || thread.title === "新对话" || thread.title === placeholderTitle;
+          if (!isPlaceholderTitle) return;
+
+          generateThreadTitleWithAI(normalizedMessages, selectedModel ?? undefined)
+            .then(async (title) => {
+              if (!title) return;
+              const renamedThread = await editThread(thread.id, { title });
+              setCurrentThread(renamedThread);
+              queryClient.invalidateQueries({ queryKey: ["threads"] });
+            })
+            .catch((error) => {
+              // 自动命名失败静默处理，保留占位标题
+              console.warn("AI 自动命名失败，保留占位标题:", error);
+            });
+        };
+
         const persistMessages = (threadId: string) =>
           editThread(threadId, { messages: normalizedMessages })
             .then((updatedThread) => {
               console.log("Thread updated successfully:", updatedThread.id);
               setCurrentThread(updatedThread);
+              autoNameFirstRound(updatedThread);
             })
             .catch((error) => {
               console.error("Failed to update thread:", error);

--- a/packages/app/src/hooks/use-threads.ts
+++ b/packages/app/src/hooks/use-threads.ts
@@ -1,4 +1,6 @@
-import { deleteThread, getAllThreads, getThreadsBybookId } from "@/services/thread-service";
+import { deleteThread, editThread, getAllThreads, getThreadById, getThreadsBybookId } from "@/services/thread-service";
+import { generateThreadTitleWithAI } from "@/services/thread-title-service";
+import { useThreadStore } from "@/store/thread-store";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { toast } from "sonner";
@@ -41,6 +43,65 @@ export const useThreads = ({ bookId }: UseThreadsProps = {}) => {
     [queryClient, bookId],
   );
 
+  // 重命名 thread
+  const handleRenameThread = useCallback(
+    async (threadId: string, title: string) => {
+      try {
+        const updatedThread = await editThread(threadId, { title });
+        toast.success("对话重命名成功");
+
+        // 若重命名的是当前对话，同步更新 store
+        const { currentThread, setCurrentThread } = useThreadStore.getState();
+        if (currentThread?.id === threadId) {
+          setCurrentThread(updatedThread);
+        }
+
+        // 刷新所有 threads 列表
+        queryClient.invalidateQueries({ queryKey: ["threads"] });
+      } catch (error) {
+        console.error("重命名对话失败:", error);
+        toast.error("重命名对话失败");
+        throw error;
+      }
+    },
+    [queryClient],
+  );
+
+  // AI 重命名 thread（基于当前全部对话内容，手动触发）
+  const handleAiRenameThread = useCallback(
+    async (threadId: string) => {
+      const toastId = toast.loading("正在生成标题...");
+      try {
+        const thread = await getThreadById(threadId);
+        if (!thread.messages?.length) {
+          toast.error("对话为空，无法生成标题", { id: toastId });
+          return;
+        }
+
+        const title = await generateThreadTitleWithAI(thread.messages);
+        if (!title) {
+          throw new Error("未能生成标题");
+        }
+
+        const updatedThread = await editThread(threadId, { title });
+
+        // 若重命名的是当前对话，同步更新 store
+        const { currentThread, setCurrentThread } = useThreadStore.getState();
+        if (currentThread?.id === threadId) {
+          setCurrentThread(updatedThread);
+        }
+
+        // 刷新所有 threads 列表
+        queryClient.invalidateQueries({ queryKey: ["threads"] });
+        toast.success(`已重命名为「${title}」`, { id: toastId });
+      } catch (error) {
+        console.error("AI 重命名失败:", error);
+        toast.error("AI 重命名失败", { id: toastId });
+      }
+    },
+    [queryClient],
+  );
+
   return {
     // 查询相关
     threads: threads ?? [],
@@ -50,5 +111,7 @@ export const useThreads = ({ bookId }: UseThreadsProps = {}) => {
 
     // 操作相关
     handleDeleteThread,
+    handleRenameThread,
+    handleAiRenameThread,
   };
 };

--- a/packages/app/src/hooks/use-threads.ts
+++ b/packages/app/src/hooks/use-threads.ts
@@ -1,6 +1,7 @@
 import { deleteThread, editThread, getAllThreads, getThreadById, getThreadsBybookId } from "@/services/thread-service";
 import { generateThreadTitleWithAI } from "@/services/thread-title-service";
 import { useThreadStore } from "@/store/thread-store";
+import type { ThreadSummary } from "@/types/thread";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { toast } from "sonner";
@@ -67,6 +68,28 @@ export const useThreads = ({ bookId }: UseThreadsProps = {}) => {
     [queryClient],
   );
 
+  // 切换星标：写反 starred 并刷新列表/当前对话
+  const handleToggleStar = useCallback(
+    async (thread: ThreadSummary) => {
+      try {
+        const updatedThread = await editThread(thread.id, { starred: !thread.starred });
+
+        // 若星标的是当前对话，同步更新 store
+        const { currentThread, setCurrentThread } = useThreadStore.getState();
+        if (currentThread?.id === thread.id) {
+          setCurrentThread(updatedThread);
+        }
+
+        // 刷新所有 threads 列表
+        queryClient.invalidateQueries({ queryKey: ["threads"] });
+      } catch (error) {
+        console.error("更新星标失败:", error);
+        toast.error("更新星标失败");
+      }
+    },
+    [queryClient],
+  );
+
   // AI 重命名 thread（基于当前全部对话内容，手动触发）
   const handleAiRenameThread = useCallback(
     async (threadId: string) => {
@@ -113,5 +136,6 @@ export const useThreads = ({ bookId }: UseThreadsProps = {}) => {
     handleDeleteThread,
     handleRenameThread,
     handleAiRenameThread,
+    handleToggleStar,
   };
 };

--- a/packages/app/src/lib/export-thread-html.ts
+++ b/packages/app/src/lib/export-thread-html.ts
@@ -1,0 +1,202 @@
+import type { Thread } from "@/types/thread";
+import { save } from "@tauri-apps/plugin-dialog";
+import { writeTextFile } from "@tauri-apps/plugin-fs";
+import type { UIMessage } from "ai";
+import dayjs from "dayjs";
+import { marked } from "marked";
+import { toast } from "sonner";
+import { type ExportMeta, resolveBookTitle, toSafeFileName } from "./export-thread-markdown";
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+/**
+ * 轻量净化：去掉 script/iframe 等危险标签、on* 事件属性和 javascript: 链接。
+ * 项目无 DOMPurify 类依赖，此为正则级防护，内容来自用户自己的对话记录，威胁模型有限。
+ */
+function sanitizeHtml(html: string): string {
+  return html
+    .replace(/<(script|iframe|object|embed|form|link|meta|style)\b[\s\S]*?(<\/\s*\1\s*>|\/?>)/gi, "")
+    .replace(/\son\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, "")
+    .replace(/(href|src)\s*=\s*(["']?)\s*javascript:[^"'>]*\2/gi, "$1=$2#$2");
+}
+
+/**
+ * 导出文档的共享样式（HTML 导出与图片导出共用，单一事实源）
+ */
+export const EXPORT_HTML_CSS = `
+  * { box-sizing: border-box; }
+  body { margin: 0; padding: 32px 16px; background: #f5f1e8; color: #3a3226;
+         font-family: "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif; line-height: 1.7; }
+  .container { max-width: 760px; margin: 0 auto; }
+  header { margin-bottom: 24px; padding-bottom: 16px; border-bottom: 1px solid #ddd3b8; }
+  h1 { font-size: 22px; margin: 0 0 8px; }
+  .meta { font-size: 13px; color: #8a7c60; }
+  .meta span + span::before { content: " · "; }
+  .message { margin-bottom: 16px; display: flex; flex-direction: column; }
+  .message.user { align-items: flex-end; }
+  .message.assistant { align-items: flex-start; }
+  .role { font-size: 12px; color: #8a7c60; margin-bottom: 4px; padding: 0 4px; }
+  .bubble { max-width: 88%; padding: 12px 16px; border-radius: 12px; box-shadow: 0 1px 3px rgba(60, 50, 30, 0.08); }
+  .user .bubble { background: #e9d6a6; border-radius: 12px 12px 4px 12px; }
+  .assistant .bubble { background: #fffdf7; border: 1px solid #e5dcc4; border-radius: 12px 12px 12px 4px; }
+  .bubble > :first-child { margin-top: 0; }
+  .bubble > :last-child { margin-bottom: 0; }
+  blockquote { margin: 8px 0; padding: 4px 12px; border-left: 3px solid #a05a2c;
+               background: rgba(160, 90, 44, 0.07); color: #6b5c42; border-radius: 0 6px 6px 0; }
+  pre { background: #3a2e1e; color: #f0e6d0; padding: 12px 14px; border-radius: 8px; overflow-x: auto; font-size: 13px; }
+  code { font-family: Consolas, "Courier New", monospace; }
+  p code, li code { background: rgba(160, 90, 44, 0.1); padding: 1px 5px; border-radius: 4px; font-size: 90%; }
+  pre code { background: none; padding: 0; }
+  table { border-collapse: collapse; margin: 8px 0; }
+  th, td { border: 1px solid #ddd3b8; padding: 6px 10px; }
+  th { background: #eee2c2; }
+  img { max-width: 100%; }
+  a { color: #a05a2c; }
+  footer { margin-top: 24px; padding-top: 12px; border-top: 1px solid #ddd3b8;
+           font-size: 12px; color: #8a7c60; text-align: center; }
+`;
+
+/**
+ * 导出文档头（标题 + 元信息行），HTML 导出与图片导出共用
+ */
+export function buildExportHeaderHtml(meta: { title: string; bookTitle?: string; messageCount: number }): string {
+  return `<header>
+    <h1>${escapeHtml(meta.title || "未命名对话")}</h1>
+    <div class="meta">
+      ${meta.bookTitle ? `<span>书名：《${escapeHtml(meta.bookTitle)}》</span>` : ""}
+      <span>导出时间：${dayjs().format("YYYY-MM-DD HH:mm:ss")}</span>
+      <span>消息数：${meta.messageCount}</span>
+    </div>
+  </header>`;
+}
+
+/**
+ * 将单条消息的 parts 渲染为 HTML 片段（text → marked，quote → blockquote）
+ */
+export function renderMessageHtml(message: UIMessage): string {
+  const parts = Array.isArray(message.parts) ? message.parts : [];
+  let html = "";
+  let textBuffer = "";
+
+  const flushText = () => {
+    const text = textBuffer.trim();
+    if (text) {
+      html += sanitizeHtml(marked.parse(text, { async: false }));
+    }
+    textBuffer = "";
+  };
+
+  for (const part of parts as any[]) {
+    if (part?.type === "text") {
+      textBuffer += part.text ?? "";
+      continue;
+    }
+
+    if (part?.type === "quote") {
+      flushText();
+      const quote = escapeHtml(String(part.text ?? "")).replace(/\n/g, "<br>");
+      if (quote.trim()) {
+        html += `<blockquote>${quote}</blockquote>`;
+      }
+    }
+  }
+
+  flushText();
+  return html;
+}
+
+/**
+ * 将一组消息渲染为消息流 HTML（用户/AI 气泡分区）
+ */
+export function buildMessagesHtml(messages: UIMessage[]): string {
+  return messages
+    .map((message) => {
+      const body = renderMessageHtml(message);
+      if (!body) return "";
+      const isUser = message.role === "user";
+      return `<div class="message ${isUser ? "user" : "assistant"}">
+  <div class="role">${isUser ? "用户" : "AI"}</div>
+  <div class="bubble">${body}</div>
+</div>`;
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+/**
+ * 将一组消息构建为自包含单文件 HTML 文档（样式全内联，无外部依赖）
+ */
+export function buildThreadHtml(messages: UIMessage[], meta: { title: string; bookTitle?: string }): string {
+  const title = meta.title || "未命名对话";
+
+  return `<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>${escapeHtml(title)}</title>
+<style>${EXPORT_HTML_CSS}</style>
+</head>
+<body>
+<div class="container">
+  ${buildExportHeaderHtml({ title, bookTitle: meta.bookTitle, messageCount: messages.length })}
+  <main>
+${buildMessagesHtml(messages)}
+  </main>
+  <footer>由 SageRead 导出</footer>
+</div>
+</body>
+</html>
+`;
+}
+
+/**
+ * 弹出保存对话框并将一组消息导出为自包含 HTML 文件
+ */
+export async function exportMessagesToHtml(messages: UIMessage[], meta: ExportMeta): Promise<boolean> {
+  try {
+    const exportable = messages.filter((m) => renderMessageHtml(m));
+    if (exportable.length === 0) {
+      toast.error("没有可导出的内容");
+      return false;
+    }
+
+    const bookTitle = await resolveBookTitle(meta.bookId);
+    const html = buildThreadHtml(exportable, { title: meta.title, bookTitle });
+
+    const path = await save({
+      defaultPath: `${toSafeFileName(meta.title)}.html`,
+      filters: [
+        {
+          name: "HTML",
+          extensions: ["html"],
+        },
+      ],
+    });
+
+    // 用户取消保存，不视为失败
+    if (!path) {
+      return false;
+    }
+
+    await writeTextFile(path, html);
+    toast.success(meta.successText ?? "对话导出成功");
+    return true;
+  } catch (error) {
+    console.error("导出对话失败:", error);
+    toast.error("导出对话失败");
+    return false;
+  }
+}
+
+/**
+ * 导出整个对话为自包含 HTML 文件
+ */
+export async function exportThreadToHtml(thread: Thread): Promise<boolean> {
+  return exportMessagesToHtml(thread.messages, {
+    title: thread.title || "未命名对话",
+    bookId: thread.book_id,
+  });
+}

--- a/packages/app/src/lib/export-thread-image.ts
+++ b/packages/app/src/lib/export-thread-image.ts
@@ -1,0 +1,380 @@
+import type { Thread } from "@/types/thread";
+import { save } from "@tauri-apps/plugin-dialog";
+import { writeFile } from "@tauri-apps/plugin-fs";
+import type { UIMessage } from "ai";
+import dayjs from "dayjs";
+import { toast } from "sonner";
+import { EXPORT_HTML_CSS, buildExportHeaderHtml, buildMessagesHtml } from "./export-thread-html";
+import { type ExportMeta, resolveBookTitle, toSafeFileName } from "./export-thread-markdown";
+
+const MAX_HEIGHT = 16000; // Chromium 画布高度上限 16384，留余量
+const RENDER_WIDTH = 880;
+const RENDER_SCALE = 2; // 2x 渲染提升清晰度
+
+/**
+ * 迷你 html-to-image：把导出 HTML 填进离屏隐藏容器（有布局、不可见），
+ * 用 XMLSerializer 序列化进 SVG foreignObject，再绘制到 canvas。
+ * 内容全内联无外部资源，canvas 不会被污染。
+ */
+export async function renderMessagesToPngBlob(
+  messages: UIMessage[],
+  meta: { title: string; bookTitle?: string },
+): Promise<Blob> {
+  // 离屏定位放在外层包装元素上；被序列化的容器自身不能有 left:-9999px，
+  // 否则 SVG 视口内同样偏移 -9999px 渲染空白（已踩坑验证）
+  const offscreen = document.createElement("div");
+  offscreen.style.cssText = "position:absolute;left:-9999px;top:0;";
+  const container = document.createElement("div");
+  // 容器内联 body 等价样式（EXPORT_HTML_CSS 里的 body 选择器对 div 不生效）
+  container.style.cssText = `width:${RENDER_WIDTH}px;background:#f5f1e8;color:#3a3226;font-family:"Segoe UI","PingFang SC","Microsoft YaHei",sans-serif;line-height:1.7;padding:32px 16px;`;
+  container.innerHTML = `<style>${EXPORT_HTML_CSS}</style><div class="container">${buildExportHeaderHtml({
+    title: meta.title,
+    bookTitle: meta.bookTitle,
+    messageCount: messages.length,
+  })}<main>${buildMessagesHtml(messages)}</main></div>`;
+  offscreen.appendChild(container);
+  document.body.appendChild(offscreen);
+
+  try {
+    // 高度超限：从尾部移除消息直到放得下，再补截断提示
+    if (container.offsetHeight > MAX_HEIGHT) {
+      const messageEls = Array.from(container.querySelectorAll(".message"));
+      for (let i = messageEls.length - 1; i >= 0 && container.offsetHeight > MAX_HEIGHT - 60; i--) {
+        messageEls[i].remove();
+      }
+      const notice = document.createElement("div");
+      notice.style.cssText = "text-align:center;font-size:12px;color:#8a7c60;padding:12px 0;";
+      notice.textContent = "对话过长，已截断（完整内容请导出 Markdown）";
+      container.querySelector("main")?.appendChild(notice);
+    }
+
+    const height = Math.min(container.offsetHeight, MAX_HEIGHT);
+    const serialized = new XMLSerializer().serializeToString(container);
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${RENDER_WIDTH}" height="${height}"><foreignObject width="100%" height="100%">${serialized}</foreignObject></svg>`;
+    // 注意用 data: URL 而非 blob: URL——blob 加载的 foreignObject SVG 会被 Chromium 标记污染，无法 toBlob
+    const svgUrl = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+
+    const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const el = new Image();
+      el.onload = () => resolve(el);
+      el.onerror = () => reject(new Error("SVG 图像加载失败"));
+      el.src = svgUrl;
+    });
+
+    const canvas = document.createElement("canvas");
+    canvas.width = RENDER_WIDTH * RENDER_SCALE;
+    canvas.height = height * RENDER_SCALE;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("无法创建画布上下文");
+    ctx.scale(RENDER_SCALE, RENDER_SCALE);
+    ctx.drawImage(img, 0, 0);
+
+    const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, "image/png"));
+    if (!blob) throw new Error("图片生成失败");
+    return blob;
+  } finally {
+    offscreen.remove();
+  }
+}
+
+/* ------------------------------------------------------------
+ * 以下为纯 Canvas 手绘实现（foreignObject 路径失败时的回落），请勿删除
+ * ---------------------------------------------------------- */
+
+const PADDING = 40;
+const CONTENT_WIDTH = RENDER_WIDTH - PADDING * 2;
+const BUBBLE_MAX_WIDTH = 640;
+const BUBBLE_PADDING_X = 16;
+const BUBBLE_PADDING_Y = 12;
+const BADGE_HEIGHT = 20;
+const LINE_HEIGHT = 22;
+
+const FONT_BODY = "14px 'Segoe UI', 'Microsoft YaHei', sans-serif";
+const FONT_TITLE = "bold 20px 'Segoe UI', 'Microsoft YaHei', sans-serif";
+const FONT_META = "12px 'Segoe UI', 'Microsoft YaHei', sans-serif";
+const FONT_BADGE = "12px 'Segoe UI', 'Microsoft YaHei', sans-serif";
+
+interface DrawBlock {
+  kind: "text" | "quote";
+  lines: string[];
+}
+
+interface LayoutMessage {
+  isUser: boolean;
+  blocks: DrawBlock[];
+}
+
+/** 逐字断行：中文按字断、英文到边也按字断，measureText 实测宽度 */
+function wrapText(ctx: CanvasRenderingContext2D, text: string, maxWidth: number): string[] {
+  const lines: string[] = [];
+  for (const paragraph of text.split("\n")) {
+    if (!paragraph) {
+      lines.push("");
+      continue;
+    }
+    let line = "";
+    for (const char of paragraph) {
+      if (line && ctx.measureText(line + char).width > maxWidth) {
+        lines.push(line);
+        line = char;
+      } else {
+        line += char;
+      }
+    }
+    if (line) {
+      lines.push(line);
+    }
+  }
+  return lines;
+}
+
+function collectBlocks(message: UIMessage, ctx: CanvasRenderingContext2D): DrawBlock[] {
+  const parts = Array.isArray(message.parts) ? message.parts : [];
+  const blocks: DrawBlock[] = [];
+  let textBuffer = "";
+
+  const flushText = () => {
+    const text = textBuffer.trim();
+    if (text) {
+      blocks.push({ kind: "text", lines: wrapText(ctx, text, BUBBLE_MAX_WIDTH - BUBBLE_PADDING_X * 2) });
+    }
+    textBuffer = "";
+  };
+
+  for (const part of parts as any[]) {
+    if (part?.type === "text") {
+      textBuffer += part.text ?? "";
+      continue;
+    }
+    if (part?.type === "quote") {
+      flushText();
+      const quote = String(part.text ?? "").trim();
+      if (quote) {
+        blocks.push({ kind: "quote", lines: wrapText(ctx, quote, CONTENT_WIDTH - 32) });
+      }
+    }
+  }
+
+  flushText();
+  return blocks;
+}
+
+function drawRoundRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number,
+) {
+  ctx.beginPath();
+  if (typeof ctx.roundRect === "function") {
+    ctx.roundRect(x, y, width, height, radius);
+  } else {
+    ctx.rect(x, y, width, height);
+  }
+  ctx.fill();
+}
+
+function blockHeight(block: DrawBlock): number {
+  if (block.kind === "quote") {
+    return block.lines.length * LINE_HEIGHT + 16;
+  }
+  return block.lines.length * LINE_HEIGHT + BUBBLE_PADDING_Y * 2;
+}
+
+/** 纯 Canvas 手绘渲染（回落路径）：输出为源码级排版，仅在 foreignObject 不可用时使用 */
+async function renderMessagesToPngBlobFallback(
+  messages: UIMessage[],
+  meta: { title: string; bookTitle?: string },
+): Promise<Blob> {
+  const title = meta.title || "未命名对话";
+  const metaLine = [meta.bookTitle ? `《${meta.bookTitle}》` : "", dayjs().format("YYYY-MM-DD HH:mm:ss")].filter(
+    Boolean,
+  );
+
+  const measureCanvas = document.createElement("canvas");
+  const measureCtx = measureCanvas.getContext("2d");
+  if (!measureCtx) throw new Error("无法创建画布上下文");
+  measureCtx.font = FONT_BODY;
+
+  const layoutMessages: LayoutMessage[] = messages
+    .map((message) => ({
+      isUser: message.role === "user",
+      blocks: collectBlocks(message, measureCtx),
+    }))
+    .filter((m) => m.blocks.length > 0);
+
+  const HEADER_HEIGHT = 84;
+  const FOOTER_HEIGHT = 48;
+  let y = PADDING + HEADER_HEIGHT;
+  let truncated = false;
+  const visibleMessages: LayoutMessage[] = [];
+
+  for (const message of layoutMessages) {
+    const messageHeight =
+      BADGE_HEIGHT + 6 + message.blocks.reduce((sum, block) => sum + blockHeight(block) + 8, 0) + 12;
+    if (y + messageHeight > MAX_HEIGHT - FOOTER_HEIGHT) {
+      truncated = true;
+      break;
+    }
+    visibleMessages.push(message);
+    y += messageHeight;
+  }
+
+  const totalHeight = Math.min(y + FOOTER_HEIGHT, MAX_HEIGHT);
+
+  const canvas = document.createElement("canvas");
+  canvas.width = RENDER_WIDTH;
+  canvas.height = totalHeight;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("无法创建画布上下文");
+
+  ctx.fillStyle = "#f7f4ee";
+  ctx.fillRect(0, 0, RENDER_WIDTH, totalHeight);
+  ctx.textBaseline = "top";
+
+  let cursorY = PADDING;
+  ctx.font = FONT_TITLE;
+  ctx.fillStyle = "#3a3226";
+  ctx.fillText(title, PADDING, cursorY, CONTENT_WIDTH);
+  cursorY += 30;
+  ctx.font = FONT_META;
+  ctx.fillStyle = "#8a7c60";
+  ctx.fillText(metaLine.join("  ·  "), PADDING, cursorY, CONTENT_WIDTH);
+  cursorY += 24;
+  ctx.strokeStyle = "#ddd3b8";
+  ctx.beginPath();
+  ctx.moveTo(PADDING, cursorY);
+  ctx.lineTo(RENDER_WIDTH - PADDING, cursorY);
+  ctx.stroke();
+  cursorY += 30;
+
+  ctx.font = FONT_BODY;
+  for (const message of visibleMessages) {
+    const badgeText = message.isUser ? "用户" : "AI";
+    ctx.font = FONT_BADGE;
+    const badgeWidth = ctx.measureText(badgeText).width + 16;
+    const badgeX = message.isUser ? RENDER_WIDTH - PADDING - badgeWidth : PADDING;
+    ctx.fillStyle = "#a05a2c";
+    drawRoundRect(ctx, badgeX, cursorY, badgeWidth, BADGE_HEIGHT, 9);
+    ctx.fillStyle = "#fffdf7";
+    ctx.fillText(badgeText, badgeX + 8, cursorY + 4);
+    cursorY += BADGE_HEIGHT + 6;
+    ctx.font = FONT_BODY;
+
+    for (const block of message.blocks) {
+      if (block.kind === "quote") {
+        const height = blockHeight(block);
+        ctx.fillStyle = "rgba(160, 90, 44, 0.08)";
+        drawRoundRect(ctx, PADDING, cursorY, CONTENT_WIDTH, height, 6);
+        ctx.fillStyle = "#a05a2c";
+        ctx.fillRect(PADDING, cursorY, 3, height);
+        ctx.fillStyle = "#6b5c42";
+        block.lines.forEach((line, i) => {
+          ctx.fillText(line, PADDING + 14, cursorY + 8 + i * LINE_HEIGHT);
+        });
+        cursorY += height + 8;
+        continue;
+      }
+
+      const maxLineWidth = Math.max(...block.lines.map((line) => ctx.measureText(line).width), 0);
+      const bubbleWidth = Math.min(maxLineWidth + BUBBLE_PADDING_X * 2, BUBBLE_MAX_WIDTH);
+      const bubbleHeight = blockHeight(block);
+      const bubbleX = message.isUser ? RENDER_WIDTH - PADDING - bubbleWidth : PADDING;
+
+      ctx.fillStyle = message.isUser ? "#e9d6a6" : "#fffdf7";
+      drawRoundRect(ctx, bubbleX, cursorY, bubbleWidth, bubbleHeight, 12);
+      if (!message.isUser) {
+        ctx.strokeStyle = "#e5dcc4";
+        ctx.beginPath();
+        if (typeof ctx.roundRect === "function") {
+          ctx.roundRect(bubbleX, cursorY, bubbleWidth, bubbleHeight, 12);
+        } else {
+          ctx.rect(bubbleX, cursorY, bubbleWidth, bubbleHeight);
+        }
+        ctx.stroke();
+      }
+
+      ctx.fillStyle = "#3a3226";
+      block.lines.forEach((line, i) => {
+        ctx.fillText(line, bubbleX + BUBBLE_PADDING_X, cursorY + BUBBLE_PADDING_Y + i * LINE_HEIGHT);
+      });
+      cursorY += bubbleHeight + 8;
+    }
+
+    cursorY += 12;
+  }
+
+  ctx.font = FONT_META;
+  ctx.fillStyle = "#8a7c60";
+  const footerText = truncated ? "对话过长，已截断（完整内容请导出 Markdown）" : "由 SageRead 导出";
+  const footerWidth = ctx.measureText(footerText).width;
+  ctx.fillText(footerText, (RENDER_WIDTH - footerWidth) / 2, totalHeight - FOOTER_HEIGHT + 14);
+
+  const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, "image/png"));
+  if (!blob) throw new Error("图片生成失败");
+  return blob;
+}
+
+/**
+ * 弹出保存对话框并将一组消息渲染为 PNG 长图。
+ * 主路径为 HTML 渲染（排版与 HTML 导出一致），失败时回落纯 Canvas 手绘。
+ */
+export async function exportMessagesToImage(messages: UIMessage[], meta: ExportMeta): Promise<boolean> {
+  if (!buildMessagesHtml(messages)) {
+    toast.error("没有可导出的内容");
+    return false;
+  }
+
+  const bookTitle = await resolveBookTitle(meta.bookId);
+
+  let blob: Blob;
+  try {
+    blob = await renderMessagesToPngBlob(messages, { title: meta.title, bookTitle });
+  } catch (error) {
+    console.warn("[导出图片] foreignObject 渲染失败，回落纯 Canvas 手绘:", error);
+    try {
+      blob = await renderMessagesToPngBlobFallback(messages, { title: meta.title, bookTitle });
+    } catch (fallbackError) {
+      console.error("导出对话失败:", fallbackError);
+      toast.error("导出对话失败");
+      return false;
+    }
+  }
+
+  try {
+    const path = await save({
+      defaultPath: `${toSafeFileName(meta.title)}.png`,
+      filters: [
+        {
+          name: "PNG 图片",
+          extensions: ["png"],
+        },
+      ],
+    });
+
+    // 用户取消保存，不视为失败
+    if (!path) {
+      return false;
+    }
+
+    await writeFile(path, new Uint8Array(await blob.arrayBuffer()));
+    toast.success(meta.successText ?? "对话导出成功");
+    return true;
+  } catch (error) {
+    console.error("导出对话失败:", error);
+    toast.error("导出对话失败");
+    return false;
+  }
+}
+
+/**
+ * 导出整个对话为 PNG 长图
+ */
+export async function exportThreadToImage(thread: Thread): Promise<boolean> {
+  return exportMessagesToImage(thread.messages, {
+    title: thread.title || "未命名对话",
+    bookId: thread.book_id,
+  });
+}

--- a/packages/app/src/lib/export-thread-markdown.ts
+++ b/packages/app/src/lib/export-thread-markdown.ts
@@ -6,11 +6,30 @@ import type { UIMessage } from "ai";
 import dayjs from "dayjs";
 import { toast } from "sonner";
 
+/** 导出元信息：标题 + 书籍（用于解析书名），successText 可定制成功提示 */
+export interface ExportMeta {
+  title: string;
+  bookId?: string | null;
+  successText?: string;
+}
+
+/** 按 bookId 解析书名，失败返回 undefined（不阻断导出） */
+export async function resolveBookTitle(bookId?: string | null): Promise<string | undefined> {
+  if (!bookId) return undefined;
+  const book = await getBookById(bookId).catch(() => null);
+  return book?.title;
+}
+
+/** 文件名清洗：去掉文件系统非法字符 */
+export function toSafeFileName(name: string, fallback = "未命名对话"): string {
+  return name.replace(/[<>:"/\\|?*]/g, "").trim() || fallback;
+}
+
 /**
  * 将单条消息的 parts 渲染为 Markdown。
  * 只导出 text 和 quote part；reasoning / tool 等过程性 part 与聊天页的定位一致，不进入导出文档。
  */
-function renderMessageMarkdown(message: UIMessage): string {
+export function renderMessageMarkdown(message: UIMessage): string {
   const parts = Array.isArray(message.parts) ? message.parts : [];
   const blocks: string[] = [];
   let textBuffer = "";
@@ -33,7 +52,7 @@ function renderMessageMarkdown(message: UIMessage): string {
       flushText();
       const quote = String(part.text ?? "")
         .split("\n")
-        .map((line: string) => `> ${line}`.trimEnd())
+        .map((line) => `> ${line}`.trimEnd())
         .join("\n");
       if (quote.trim()) {
         blocks.push(quote);
@@ -46,23 +65,23 @@ function renderMessageMarkdown(message: UIMessage): string {
 }
 
 /**
- * 将整个对话构建为 Markdown 文档（含元信息头）
+ * 将一组消息构建为 Markdown 文档（含元信息头）
  */
-export function buildThreadMarkdown(thread: Thread, bookTitle?: string): string {
+export function buildThreadMarkdown(messages: UIMessage[], meta: { title: string; bookTitle?: string }): string {
   const lines: string[] = [];
 
-  lines.push(`# ${thread.title || "未命名对话"}`);
+  lines.push(`# ${meta.title || "未命名对话"}`);
   lines.push("");
-  if (bookTitle) {
-    lines.push(`- 书名：《${bookTitle}》`);
+  if (meta.bookTitle) {
+    lines.push(`- 书名：《${meta.bookTitle}》`);
   }
   lines.push(`- 导出时间：${dayjs().format("YYYY-MM-DD HH:mm:ss")}`);
-  lines.push(`- 消息数：${thread.messages.length}`);
+  lines.push(`- 消息数：${messages.length}`);
   lines.push("");
   lines.push("---");
   lines.push("");
 
-  for (const message of thread.messages) {
+  for (const message of messages) {
     const body = renderMessageMarkdown(message);
     if (!body) continue;
     lines.push(message.role === "user" ? "## 🧑 用户" : "## 🤖 AI");
@@ -75,17 +94,21 @@ export function buildThreadMarkdown(thread: Thread, bookTitle?: string): string 
 }
 
 /**
- * 弹出保存对话框并将对话导出为 Markdown 文件
+ * 弹出保存对话框并将一组消息导出为 Markdown 文件
  */
-export async function exportThreadToMarkdown(thread: Thread): Promise<boolean> {
+export async function exportMessagesToMarkdown(messages: UIMessage[], meta: ExportMeta): Promise<boolean> {
   try {
-    const book = thread.book_id ? await getBookById(thread.book_id).catch(() => null) : null;
-    const markdown = buildThreadMarkdown(thread, book?.title);
+    const exportable = messages.filter((m) => renderMessageMarkdown(m));
+    if (exportable.length === 0) {
+      toast.error("没有可导出的内容");
+      return false;
+    }
 
-    const safeFileName = (thread.title || "未命名对话").replace(/[<>:"/\\|?*]/g, "").trim() || "未命名对话";
+    const bookTitle = await resolveBookTitle(meta.bookId);
+    const markdown = buildThreadMarkdown(exportable, { title: meta.title, bookTitle });
 
     const path = await save({
-      defaultPath: `${safeFileName}.md`,
+      defaultPath: `${toSafeFileName(meta.title)}.md`,
       filters: [
         {
           name: "Markdown",
@@ -100,11 +123,36 @@ export async function exportThreadToMarkdown(thread: Thread): Promise<boolean> {
     }
 
     await writeTextFile(path, markdown);
-    toast.success("对话导出成功");
+    toast.success(meta.successText ?? "对话导出成功");
     return true;
   } catch (error) {
     console.error("导出对话失败:", error);
     toast.error("导出对话失败");
     return false;
   }
+}
+
+/**
+ * 导出整个对话为 Markdown 文件
+ */
+export async function exportThreadToMarkdown(thread: Thread): Promise<boolean> {
+  return exportMessagesToMarkdown(thread.messages, {
+    title: thread.title || "未命名对话",
+    bookId: thread.book_id,
+  });
+}
+
+/**
+ * 导出单条消息为 Markdown 文件（含元信息头，标题 = 对话标题 + 消息序号）
+ */
+export async function exportMessageToMarkdown(
+  message: UIMessage,
+  options: { threadTitle?: string; bookId?: string | null; index: number },
+): Promise<boolean> {
+  const title = `${options.threadTitle || "未命名对话"}-第${options.index + 1}条`;
+  return exportMessagesToMarkdown([message], {
+    title,
+    bookId: options.bookId,
+    successText: "消息导出成功",
+  });
 }

--- a/packages/app/src/lib/export-thread-markdown.ts
+++ b/packages/app/src/lib/export-thread-markdown.ts
@@ -1,0 +1,110 @@
+import { getBookById } from "@/services/book-service";
+import type { Thread } from "@/types/thread";
+import { save } from "@tauri-apps/plugin-dialog";
+import { writeTextFile } from "@tauri-apps/plugin-fs";
+import type { UIMessage } from "ai";
+import dayjs from "dayjs";
+import { toast } from "sonner";
+
+/**
+ * 将单条消息的 parts 渲染为 Markdown。
+ * 只导出 text 和 quote part；reasoning / tool 等过程性 part 与聊天页的定位一致，不进入导出文档。
+ */
+function renderMessageMarkdown(message: UIMessage): string {
+  const parts = Array.isArray(message.parts) ? message.parts : [];
+  const blocks: string[] = [];
+  let textBuffer = "";
+
+  const flushText = () => {
+    const text = textBuffer.trim();
+    if (text) {
+      blocks.push(text);
+    }
+    textBuffer = "";
+  };
+
+  for (const part of parts as any[]) {
+    if (part?.type === "text") {
+      textBuffer += part.text ?? "";
+      continue;
+    }
+
+    if (part?.type === "quote") {
+      flushText();
+      const quote = String(part.text ?? "")
+        .split("\n")
+        .map((line: string) => `> ${line}`.trimEnd())
+        .join("\n");
+      if (quote.trim()) {
+        blocks.push(quote);
+      }
+    }
+  }
+
+  flushText();
+  return blocks.join("\n\n");
+}
+
+/**
+ * 将整个对话构建为 Markdown 文档（含元信息头）
+ */
+export function buildThreadMarkdown(thread: Thread, bookTitle?: string): string {
+  const lines: string[] = [];
+
+  lines.push(`# ${thread.title || "未命名对话"}`);
+  lines.push("");
+  if (bookTitle) {
+    lines.push(`- 书名：《${bookTitle}》`);
+  }
+  lines.push(`- 导出时间：${dayjs().format("YYYY-MM-DD HH:mm:ss")}`);
+  lines.push(`- 消息数：${thread.messages.length}`);
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+
+  for (const message of thread.messages) {
+    const body = renderMessageMarkdown(message);
+    if (!body) continue;
+    lines.push(message.role === "user" ? "## 🧑 用户" : "## 🤖 AI");
+    lines.push("");
+    lines.push(body);
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * 弹出保存对话框并将对话导出为 Markdown 文件
+ */
+export async function exportThreadToMarkdown(thread: Thread): Promise<boolean> {
+  try {
+    const book = thread.book_id ? await getBookById(thread.book_id).catch(() => null) : null;
+    const markdown = buildThreadMarkdown(thread, book?.title);
+
+    const safeFileName = (thread.title || "未命名对话").replace(/[<>:"/\\|?*]/g, "").trim() || "未命名对话";
+
+    const path = await save({
+      defaultPath: `${safeFileName}.md`,
+      filters: [
+        {
+          name: "Markdown",
+          extensions: ["md"],
+        },
+      ],
+    });
+
+    // 用户取消保存，不视为失败
+    if (!path) {
+      return false;
+    }
+
+    await writeTextFile(path, markdown);
+    toast.success("对话导出成功");
+    return true;
+  } catch (error) {
+    console.error("导出对话失败:", error);
+    toast.error("导出对话失败");
+    return false;
+  }
+}

--- a/packages/app/src/services/ai-context-service.ts
+++ b/packages/app/src/services/ai-context-service.ts
@@ -1,5 +1,4 @@
-import { createModelInstance } from "@/ai/providers/factory";
-import { useProviderStore } from "@/store/provider-store";
+import { createModelInstance, getUtilityModel } from "@/ai/providers/factory";
 import { generateText } from "ai";
 
 export interface AIContextResponse {
@@ -20,13 +19,14 @@ export async function generateContextWithAI(
   try {
     let modelConfig = selectedModel;
     if (!modelConfig) {
-      const { selectedModel: storeModel } = useProviderStore.getState();
-      if (!storeModel) {
+      // 显式传参优先，否则用辅助模型（未配置时回落当前聊天模型）
+      const utilityModel = getUtilityModel();
+      if (!utilityModel) {
         throw new Error("没有选中的AI模型，请先在设置中配置AI模型");
       }
       modelConfig = {
-        providerId: storeModel.providerId,
-        modelId: storeModel.modelId,
+        providerId: utilityModel.providerId,
+        modelId: utilityModel.modelId,
       };
     }
 

--- a/packages/app/src/services/ai-tag-service.ts
+++ b/packages/app/src/services/ai-tag-service.ts
@@ -1,5 +1,4 @@
-import { createModelInstance } from "@/ai/providers/factory";
-import { useProviderStore } from "@/store/provider-store";
+import { createModelInstance, getUtilityModel } from "@/ai/providers/factory";
 import type { SimpleBook } from "@/types/simple-book";
 import { generateText } from "ai";
 import type { Tag } from "./tag-service";
@@ -25,16 +24,16 @@ export async function generateTagsWithAI(
   selectedModel?: { providerId: string; modelId: string },
 ): Promise<AITagResponse> {
   try {
-    // 获取当前选中的模型，如果没有传入则从store获取
+    // 获取辅助模型，如果没有传入则回落（未配置辅助模型时用当前聊天模型）
     let modelConfig = selectedModel;
     if (!modelConfig) {
-      const { selectedModel: storeModel } = useProviderStore.getState();
-      if (!storeModel) {
+      const utilityModel = getUtilityModel();
+      if (!utilityModel) {
         throw new Error("没有选中的AI模型，请先在设置中配置AI模型");
       }
       modelConfig = {
-        providerId: storeModel.providerId,
-        modelId: storeModel.modelId,
+        providerId: utilityModel.providerId,
+        modelId: utilityModel.modelId,
       };
     }
 

--- a/packages/app/src/services/thread-service.ts
+++ b/packages/app/src/services/thread-service.ts
@@ -38,6 +38,7 @@ export interface EditThreadOptions {
   title?: string;
   metadata?: Record<string, any>;
   messages?: UIMessage[];
+  starred?: boolean;
 }
 
 export async function editThread(threadId: string, options: EditThreadOptions): Promise<Thread> {
@@ -47,6 +48,7 @@ export async function editThread(threadId: string, options: EditThreadOptions): 
       title: options.title,
       metadata: options.metadata ? JSON.stringify(options.metadata) : undefined,
       messages_json: options.messages ? JSON.stringify(options.messages) : undefined,
+      starred: options.starred,
     };
 
     const updatedThread: RawThread = await invoke("edit_thread", { payload });

--- a/packages/app/src/services/thread-title-service.ts
+++ b/packages/app/src/services/thread-title-service.ts
@@ -58,7 +58,7 @@ export async function generateThreadTitleWithAI(
     const { text } = await generateText({
       model: modelInstance,
       prompt: buildTitlePrompt(userText, assistantText, latestUserText, latestAssistantText),
-      maxOutputTokens: 30,
+      maxOutputTokens: 500,
       temperature: 0.3,
     });
 

--- a/packages/app/src/services/thread-title-service.ts
+++ b/packages/app/src/services/thread-title-service.ts
@@ -1,5 +1,4 @@
-import { createModelInstance } from "@/ai/providers/factory";
-import { useProviderStore } from "@/store/provider-store";
+import { createModelInstance, getUtilityModel } from "@/ai/providers/factory";
 import { type UIMessage, generateText } from "ai";
 
 // 防御性长度上限，prompt 中要求的是 10 字以内
@@ -45,11 +44,12 @@ export async function generateThreadTitleWithAI(
 
     let modelConfig = selectedModel;
     if (!modelConfig) {
-      const { selectedModel: storeModel } = useProviderStore.getState();
-      if (!storeModel) return null;
+      // 显式传参优先，否则用辅助模型（未配置时回落当前聊天模型）
+      const utilityModel = getUtilityModel();
+      if (!utilityModel) return null;
       modelConfig = {
-        providerId: storeModel.providerId,
-        modelId: storeModel.modelId,
+        providerId: utilityModel.providerId,
+        modelId: utilityModel.modelId,
       };
     }
 

--- a/packages/app/src/services/thread-title-service.ts
+++ b/packages/app/src/services/thread-title-service.ts
@@ -1,0 +1,124 @@
+import { createModelInstance } from "@/ai/providers/factory";
+import { useProviderStore } from "@/store/provider-store";
+import { type UIMessage, generateText } from "ai";
+
+// 防御性长度上限，prompt 中要求的是 10 字以内
+const MAX_TITLE_LENGTH = 20;
+
+function extractText(message: UIMessage | undefined, limit: number): string {
+  if (!message) return "";
+  const text = (message.parts ?? [])
+    .map((part: any) => (part?.type === "text" ? part.text : ""))
+    .join("")
+    .trim();
+  return text.slice(0, limit);
+}
+
+/**
+ * 使用AI为对话生成简短标题，失败时返回 null（由调用方决定如何提示）
+ * 基于首问首答；对话超过一轮时附加最近一轮问答摘录，让标题反映整体内容
+ */
+export async function generateThreadTitleWithAI(
+  messages: UIMessage[],
+  selectedModel?: { providerId: string; modelId: string },
+): Promise<string | null> {
+  try {
+    const firstUser = messages.find((m) => m.role === "user");
+    const firstAssistant = messages.find((m) => m.role === "assistant");
+    const userText = extractText(firstUser, 200);
+    const assistantText = extractText(firstAssistant, 500);
+    if (!userText && !assistantText) return null;
+
+    // 超过一轮对话时，附加最近一轮问答的摘录
+    let latestUserText = "";
+    let latestAssistantText = "";
+    if (messages.length > 2) {
+      latestUserText = extractText(
+        messages.findLast((m) => m.role === "user"),
+        200,
+      );
+      latestAssistantText = extractText(
+        messages.findLast((m) => m.role === "assistant"),
+        300,
+      );
+    }
+
+    let modelConfig = selectedModel;
+    if (!modelConfig) {
+      const { selectedModel: storeModel } = useProviderStore.getState();
+      if (!storeModel) return null;
+      modelConfig = {
+        providerId: storeModel.providerId,
+        modelId: storeModel.modelId,
+      };
+    }
+
+    const modelInstance = createModelInstance(modelConfig.providerId, modelConfig.modelId);
+
+    const { text } = await generateText({
+      model: modelInstance,
+      prompt: buildTitlePrompt(userText, assistantText, latestUserText, latestAssistantText),
+      maxOutputTokens: 30,
+      temperature: 0.3,
+    });
+
+    return sanitizeTitle(text);
+  } catch (error) {
+    console.warn("AI生成对话标题失败:", error);
+    return null;
+  }
+}
+
+/**
+ * 构建对话标题生成的提示词
+ */
+function buildTitlePrompt(
+  userText: string,
+  assistantText: string,
+  latestUserText?: string,
+  latestAssistantText?: string,
+): string {
+  const hasLatest = !!(latestUserText || latestAssistantText);
+  if (!hasLatest) {
+    return `请根据以下阅读对话的内容，为这段对话起一个简短的标题。
+
+用户提问：${userText || "（无）"}
+
+AI回答：${assistantText || "（无）"}
+
+要求：
+1. 标题不超过10个字
+2. 概括对话的核心主题
+3. 只输出标题本身，不要引号、不要标点结尾、不要任何解释`;
+  }
+
+  return `请根据以下阅读对话的内容，为这段对话起一个简短的标题。
+
+对话开头：
+用户提问：${userText || "（无）"}
+AI回答：${assistantText || "（无）"}
+
+最近内容：
+用户提问：${latestUserText || "（无）"}
+AI回答：${latestAssistantText || "（无）"}
+
+以上是该对话的开头和最近内容，请基于对话的整体内容起标题。
+
+要求：
+1. 标题不超过10个字
+2. 概括对话的核心主题
+3. 只输出标题本身，不要引号、不要标点结尾、不要任何解释`;
+}
+
+/**
+ * 清洗AI输出：取首行、去引号、去结尾标点、限制长度
+ */
+function sanitizeTitle(rawText: string): string | null {
+  const firstLine = rawText.trim().split("\n")[0]?.trim() ?? "";
+  const cleaned = firstLine
+    .replace(/^[\s"'“”‘’「」『』《》<>#*-]+|[\s"'“”‘’「」『』《》<>]+$/g, "")
+    .replace(/[。！？!?.…；;，,、：:]+$/g, "")
+    .trim();
+  if (!cleaned) return null;
+  return cleaned.slice(0, MAX_TITLE_LENGTH);
+}

--- a/packages/app/src/store/provider-store.ts
+++ b/packages/app/src/store/provider-store.ts
@@ -14,11 +14,13 @@ export interface SelectedModel {
 interface ProviderState {
   modelProviders: ModelProvider[];
   selectedModel: SelectedModel | null;
+  utilityModel: SelectedModel | null;
   setModelProviders: (modelProviders: ModelProvider[]) => void;
   updateProvider: (providerId: string, updates: Partial<ModelProvider>) => void;
   addProvider: () => string;
   removeProvider: (providerId: string) => void;
   setSelectedModel: (model: SelectedModel | null) => void;
+  setUtilityModel: (model: SelectedModel | null) => void;
 }
 
 export const useProviderStore = create<ProviderState>()(
@@ -26,6 +28,7 @@ export const useProviderStore = create<ProviderState>()(
     (set, get) => ({
       modelProviders: predefinedProviders,
       selectedModel: null,
+      utilityModel: null,
       setModelProviders: (modelProviders: ModelProvider[]) => set({ modelProviders }),
       updateProvider: (providerId: string, updates: Partial<ModelProvider>) => {
         const { modelProviders } = get();
@@ -60,11 +63,16 @@ export const useProviderStore = create<ProviderState>()(
         set({ modelProviders: updatedProviders, selectedModel: newSelectedModel });
       },
       setSelectedModel: (selectedModel: SelectedModel | null) => set({ selectedModel }),
+      setUtilityModel: (utilityModel: SelectedModel | null) => set({ utilityModel }),
     }),
     {
       name: tauriStorageKey.modelProvider,
       storage: createJSONStorage(() => tauriStorage),
-      partialize: (state) => ({ modelProviders: state.modelProviders, selectedModel: state.selectedModel }),
+      partialize: (state) => ({
+        modelProviders: state.modelProviders,
+        selectedModel: state.selectedModel,
+        utilityModel: state.utilityModel,
+      }),
     },
   ),
 );

--- a/packages/app/src/types/thread.ts
+++ b/packages/app/src/types/thread.ts
@@ -6,6 +6,7 @@ export interface Thread {
   title: string;
   metadata: string;
   messages: UIMessage[];
+  starred: boolean;
   created_at: number;
   updated_at: number;
 }
@@ -16,6 +17,7 @@ export interface RawThread {
   title: string;
   metadata: string;
   messages: string;
+  starred: boolean;
   created_at: number;
   updated_at: number;
 }
@@ -25,6 +27,7 @@ export interface ThreadSummary {
   book_id: string | null;
   title: string;
   message_count: number;
+  starred: boolean;
   created_at: number;
   updated_at: number;
 }


### PR DESCRIPTION
## 概述

本地一系列改造中**第一批通用功能**，聚焦 AI 对话体验，共 9 个独立 commit，可逐条审：

- **对话导出为 Markdown**（`export-thread-markdown.ts`）
- **渲染式图片导出、HTML 导出与多选导出**：消息多选模式 + `export-thread-image.ts` / `export-thread-html.ts`
- **AI 对话命名与标题服务**（`thread-title-service.ts`）：自动生成对话标题；并修复推理模型（如 deepseek-v4-pro）reasoning 吃光小 `maxOutputTokens` 导致标题输出为空的问题
- **对话列表管理菜单**：重命名/删除等；列表恢复纯时间排序
- **辅助模型设置**：标题生成等轻量任务可配置独立的辅助模型
- **对话星标**：星标标记与展示
- fix: 对话收尾读取正确 thread 来源（侧边栏对话误读全局 store 导致对话分裂）

## 说明

- 这是本地 fork 改造的**第一批**，后续还有几批按依赖顺序排队（全局主题系统、WebDAV 备份与增量同步），会陆续提 PR
- 类型检查 `tsc --noEmit` 通过

如有不收的方向也请直言，相应功能留在本地自用即可。