### PR TITLE
feat: 书籍回收站——删除改软删，30 天可恢复

### DIFF
--- a/packages/app/src-tauri/src/core/books/commands.rs
+++ b/packages/app/src-tauri/src/core/books/commands.rs
@@ -117,7 +117,7 @@ pub async fn get_books(
     let opts = options.unwrap_or_default();
 
     let mut query = String::from("SELECT * FROM books");
-    let mut conditions = Vec::new();
+    let mut conditions = vec!["trashed_at IS NULL".to_string()];
 
     if let Some(search_query) = &opts.search_query {
         if !search_query.trim().is_empty() {
@@ -251,28 +251,108 @@ pub async fn update_book(
 pub async fn delete_book(app_handle: AppHandle, id: String) -> Result<(), String> {
     let db_pool = get_db_pool(&app_handle).await?;
 
-    let app_data_dir = app_handle
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("获取应用目录失败: {}", e))?;
-
-    let book_dir = app_data_dir.join("books").join(&id);
-    if book_dir.exists() {
-        std::fs::remove_dir_all(&book_dir).map_err(|e| format!("删除书籍文件失败: {}", e))?;
-    }
-
-    // 外键约束会自动删除相关的 book_status, reading_sessions 和 threads
-    let result = sqlx::query("DELETE FROM books WHERE id = ?")
+    // 软删除：仅标记 trashed_at，磁盘文件与关联数据（book_status/threads 等）全部保留，回收站可恢复
+    let result = sqlx::query("UPDATE books SET trashed_at = ? WHERE id = ? AND trashed_at IS NULL")
+        .bind(chrono::Utc::now().timestamp_millis())
         .bind(&id)
         .execute(&db_pool)
         .await
         .map_err(|e| format!("删除书籍失败: {}", e))?;
 
     if result.rows_affected() == 0 {
+        return Err("书籍不存在或已在回收站".to_string());
+    }
+
+    Ok(())
+}
+
+/// 恢复：清除 trashed_at，书籍回到书架
+#[tauri::command]
+pub async fn restore_book(app_handle: AppHandle, id: String) -> Result<(), String> {
+    let db_pool = get_db_pool(&app_handle).await?;
+
+    let result = sqlx::query("UPDATE books SET trashed_at = NULL, updated_at = ? WHERE id = ?")
+        .bind(chrono::Utc::now().timestamp_millis())
+        .bind(&id)
+        .execute(&db_pool)
+        .await
+        .map_err(|e| format!("恢复书籍失败: {}", e))?;
+
+    if result.rows_affected() == 0 {
         return Err("书籍不存在".to_string());
     }
 
     Ok(())
+}
+
+/// 回收站列表：按删除时间倒序
+#[tauri::command]
+pub async fn get_trashed_books(app_handle: AppHandle) -> Result<Vec<SimpleBook>, String> {
+    let db_pool = get_db_pool(&app_handle).await?;
+
+    let rows = sqlx::query("SELECT * FROM books WHERE trashed_at IS NOT NULL ORDER BY trashed_at DESC")
+        .fetch_all(&db_pool)
+        .await
+        .map_err(|e| format!("查询回收站失败: {}", e))?;
+
+    let books: Result<Vec<SimpleBook>, sqlx::Error> = rows.iter().map(SimpleBook::from_db_row).collect();
+    books.map_err(|e| format!("转换查询结果失败: {}", e))
+}
+
+/// 彻底删除（回收站操作/自动清理共用）：删磁盘目录 + DELETE 行（外键级联清关联数据）
+async fn purge_book_by_id(app_handle: &AppHandle, db_pool: &SqlitePool, id: &str) -> Result<(), String> {
+    let app_data_dir = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("获取应用目录失败: {}", e))?;
+
+    let book_dir = app_data_dir.join("books").join(id);
+    if book_dir.exists() {
+        std::fs::remove_dir_all(&book_dir).map_err(|e| format!("删除书籍文件失败: {}", e))?;
+    }
+
+    sqlx::query("DELETE FROM books WHERE id = ?")
+        .bind(id)
+        .execute(db_pool)
+        .await
+        .map_err(|e| format!("彻底删除书籍失败: {}", e))?;
+
+    Ok(())
+}
+
+/// 彻底删除单本书（回收站手动操作）
+#[tauri::command]
+pub async fn purge_book(app_handle: AppHandle, id: String) -> Result<(), String> {
+    let db_pool = get_db_pool(&app_handle).await?;
+    purge_book_by_id(&app_handle, &db_pool, &id).await
+}
+
+/// 回收站保留天数（将来可做成用户配置）
+const TRASH_RETENTION_DAYS: i64 = 30;
+
+/// 启动时自动清理：超过保留期的回收站书籍执行彻底删除，返回清理数量
+pub async fn purge_expired_trash(app_handle: &AppHandle) -> Result<usize, String> {
+    let db_pool = get_db_pool(app_handle).await?;
+
+    let cutoff = chrono::Utc::now().timestamp_millis() - TRASH_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+    let rows = sqlx::query("SELECT id FROM books WHERE trashed_at IS NOT NULL AND trashed_at < ?")
+        .bind(cutoff)
+        .fetch_all(&db_pool)
+        .await
+        .map_err(|e| format!("查询过期回收站书籍失败: {}", e))?;
+
+    let mut purged = 0;
+    for row in rows {
+        let id: String = row.get("id");
+        purge_book_by_id(app_handle, &db_pool, &id).await?;
+        purged += 1;
+    }
+
+    if purged > 0 {
+        log::info!("回收站自动清理：彻底删除 {} 本超过 {} 天的书籍", purged, TRASH_RETENTION_DAYS);
+    }
+
+    Ok(purged)
 }
 
 #[tauri::command]
@@ -371,11 +451,11 @@ pub async fn get_books_with_status(
          s.completed_at, s.metadata, s.created_at as status_created_at, s.updated_at as status_updated_at 
          FROM books b LEFT JOIN book_status s ON b.id = s.book_id"
     );
-    let mut conditions = Vec::new();
+    let mut conditions = vec!["b.trashed_at IS NULL".to_string()];
 
     if let Some(search_query) = &opts.search_query {
         if !search_query.trim().is_empty() {
-            conditions.push("(b.title LIKE ? OR b.author LIKE ?)");
+            conditions.push("(b.title LIKE ? OR b.author LIKE ?)".to_string());
         }
     }
 
@@ -391,7 +471,7 @@ pub async fn get_books_with_status(
         None
     };
 
-    if let Some(ref condition) = tag_condition {
+    if let Some(condition) = tag_condition {
         conditions.push(condition);
     }
 

--- a/packages/app/src-tauri/src/core/books/models.rs
+++ b/packages/app/src-tauri/src/core/books/models.rs
@@ -15,6 +15,8 @@ pub struct SimpleBook {
     pub file_size: i64,
     pub language: String,
     pub tags: Option<Vec<String>>,
+    #[serde(rename = "trashedAt")]
+    pub trashed_at: Option<i64>,
     #[serde(rename = "createdAt")]
     pub created_at: i64,
     #[serde(rename = "updatedAt")]
@@ -128,6 +130,7 @@ impl SimpleBook {
             file_size,
             language,
             tags: None,
+            trashed_at: None,
             created_at: now,
             updated_at: now,
         }
@@ -149,6 +152,7 @@ impl SimpleBook {
             file_size: row.try_get("file_size")?,
             language: row.try_get("language")?,
             tags,
+            trashed_at: row.try_get("trashed_at")?,
             created_at: row.try_get("created_at")?,
             updated_at: row.try_get("updated_at")?,
         })

--- a/packages/app/src-tauri/src/core/database.rs
+++ b/packages/app/src-tauri/src/core/database.rs
@@ -43,12 +43,32 @@ pub async fn initialize(app_handle: &AppHandle) -> Result<SqlitePool, Box<dyn st
         .await?;
     println!("Database schema initialized.");
 
+    run_migrations(&pool).await?;
+
     if is_new_db {
         initialize_default_skills(&pool).await?;
     }
 
     Ok(pool)
 }
+
+/// fork 专属迁移通道：上游同步 schema.sql 时的增量变更都放这里，避免改 schema.sql 冲突。
+/// 所有迁移必须幂等。
+async fn run_migrations(pool: &SqlitePool) -> Result<(), Box<dyn std::error::Error>> {
+    // books.trashed_at（回收站软删除时间戳，毫秒，可空）
+    let result = sqlx::query("ALTER TABLE books ADD COLUMN trashed_at INTEGER")
+        .execute(pool)
+        .await;
+
+    match result {
+        Ok(_) => println!("Migration applied: books.trashed_at added."),
+        Err(e) if e.to_string().contains("duplicate column name") => {}
+        Err(e) => return Err(e.into()),
+    }
+
+    Ok(())
+}
+
 
 async fn initialize_default_skills(pool: &SqlitePool) -> Result<(), Box<dyn std::error::Error>> {
     let default_skills_json = include_str!("./default-skills.json");

--- a/packages/app/src-tauri/src/core/schema.sql
+++ b/packages/app/src-tauri/src/core/schema.sql
@@ -1,3 +1,4 @@
+-- 注意：books.trashed_at 列由 database.rs 的 fork 专属迁移添加，勿在此定义（避免与 ALTER 重复）
 CREATE TABLE IF NOT EXISTS threads (
     id TEXT PRIMARY KEY NOT NULL,
     book_id TEXT,

--- a/packages/app/src-tauri/src/lib.rs
+++ b/packages/app/src-tauri/src/lib.rs
@@ -17,6 +17,9 @@ use crate::core::{
         get_books_with_status,
         get_reading_session,
         get_reading_sessions_by_book,
+        get_trashed_books,
+        purge_book,
+        restore_book,
         save_book,
         update_book,
         update_book_note,
@@ -111,6 +114,12 @@ pub fn run() {
                 let state = app_handle.state::<AppState>();
                 let mut db_pool_guard = state.db_pool.lock().await;
                 *db_pool_guard = Some(pool);
+
+                // 启动时清理回收站：超过保留期的书籍彻底删除
+                drop(db_pool_guard);
+                if let Err(e) = core::books::commands::purge_expired_trash(&app_handle).await {
+                    log::error!("回收站自动清理失败: {}", e);
+                }
             });
             Ok(())
         })
@@ -127,6 +136,9 @@ pub fn run() {
             get_book_by_id,
             update_book,
             delete_book,
+            restore_book,
+            get_trashed_books,
+            purge_book,
             get_book_status,
             update_book_status,
             get_books_with_status,

--- a/packages/app/src/components/home-layout.tsx
+++ b/packages/app/src/components/home-layout.tsx
@@ -3,6 +3,7 @@ import { useBookUpload } from "@/hooks/use-book-upload";
 import { useSafeAreaInsets } from "@/hooks/use-safe-areaInsets";
 import ChatPage from "@/pages/chat";
 import LibraryPage from "@/pages/library";
+import TrashPage from "@/pages/library/trash";
 import SkillsPage from "@/pages/skills";
 import StatisticsPage from "@/pages/statistics";
 import { useAppSettingsStore } from "@/store/app-settings-store";
@@ -113,6 +114,14 @@ const HomeLayout = () => {
               element={
                 <div className="flex h-full flex-1 flex-col overflow-hidden rounded-xl shadow-around">
                   <ChatPage />
+                </div>
+              }
+            />
+            <Route
+              path="/trash"
+              element={
+                <div className="flex h-full flex-1 flex-col rounded-xl border bg-background shadow-around">
+                  <TrashPage />
                 </div>
               }
             />

--- a/packages/app/src/components/sidebar.tsx
+++ b/packages/app/src/components/sidebar.tsx
@@ -6,10 +6,11 @@ import { useBooksOperations } from "@/pages/library/hooks/use-books-operations";
 import { useLibraryUI } from "@/pages/library/hooks/use-library-ui";
 import { useTagsManagement } from "@/pages/library/hooks/use-tags-management";
 import { useTagsOperations } from "@/pages/library/hooks/use-tags-operations";
+import { getTrashedBooks } from "@/services/book-service";
 import { useAppSettingsStore } from "@/store/app-settings-store";
 import { useLibraryStore } from "@/store/library-store";
 import clsx from "clsx";
-import { BarChart3, Brain, ChevronDown, ChevronRight, Library, Lightbulb, Settings } from "lucide-react";
+import { BarChart3, Brain, ChevronDown, ChevronRight, Library, Lightbulb, Settings, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useLocation, useNavigate, useSearchParams } from "react-router";
 
@@ -38,7 +39,16 @@ export default function Sidebar() {
   const { handleBookUpdate } = useBooksOperations(refreshBooks);
 
   const [selectedTagsForDelete, setSelectedTagsForDelete] = useState<string[]>([]);
+  const [trashCount, setTrashCount] = useState(0);
   const sidebarRef = useRef<HTMLElement>(null);
+
+  // 回收站计数徽标（路由变化时刷新）
+  // biome-ignore lint/correctness/useExhaustiveDependencies: 仅作刷新触发，effect 内不直接引用
+  useEffect(() => {
+    getTrashedBooks()
+      .then((books) => setTrashCount(books.length))
+      .catch(() => setTrashCount(0));
+  }, [location.pathname]);
 
   const clearSelectedTags = useCallback(() => {
     setSelectedTagsForDelete([]);
@@ -212,6 +222,23 @@ export default function Sidebar() {
           })}
         </nav>
         <div className="space-y-1 px-2 py-3">
+          <Link
+            to="/trash"
+            className={clsx(
+              "flex w-full items-center gap-2 rounded-md p-1 py-1 text-left text-sm transition-colors hover:bg-border",
+              location.pathname === "/trash"
+                ? "text-neutral-900 dark:text-neutral-100"
+                : "text-neutral-600 dark:text-neutral-300",
+            )}
+          >
+            <Trash2 size={16} className="flex-shrink-0" />
+            <span className="text-sm">回收站</span>
+            {trashCount > 0 && (
+              <span className="ml-auto rounded-full bg-neutral-200 px-1.5 text-neutral-600 text-xs dark:bg-neutral-700 dark:text-neutral-300">
+                {trashCount}
+              </span>
+            )}
+          </Link>
           {actionButtons.map((button, index) => {
             const Icon = button.icon;
 

--- a/packages/app/src/pages/library/trash.tsx
+++ b/packages/app/src/pages/library/trash.tsx
@@ -1,0 +1,144 @@
+import { Button } from "@/components/ui/button";
+import { getTrashedBooks, purgeBook, restoreBook } from "@/services/book-service";
+import { useLibraryStore } from "@/store/library-store";
+import type { SimpleBook } from "@/types/simple-book";
+import { convertFileSrc } from "@tauri-apps/api/core";
+import { appDataDir } from "@tauri-apps/api/path";
+import { ask } from "@tauri-apps/plugin-dialog";
+import dayjs from "dayjs";
+import { Trash2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+
+// 与 Rust 侧 TRASH_RETENTION_DAYS 保持一致
+const RETENTION_DAYS = 30;
+
+type TrashedBook = SimpleBook & { coverUrl?: string };
+
+export default function TrashPage() {
+  const { refreshBooks } = useLibraryStore();
+  const [trashedBooks, setTrashedBooks] = useState<TrashedBook[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const loadTrashedBooks = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const books = await getTrashedBooks();
+      const appDataDirPath = await appDataDir();
+      setTrashedBooks(
+        books.map((book) => ({
+          ...book,
+          coverUrl: book.coverPath ? convertFileSrc(`${appDataDirPath}/${book.coverPath}`) : undefined,
+        })),
+      );
+    } catch (error) {
+      console.error("加载回收站失败:", error);
+      toast.error("加载回收站失败");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadTrashedBooks();
+  }, [loadTrashedBooks]);
+
+  const remainingDays = (trashedAt?: number | null): number => {
+    if (!trashedAt) return RETENTION_DAYS;
+    const elapsedDays = Math.floor((Date.now() - trashedAt) / (24 * 60 * 60 * 1000));
+    return Math.max(0, RETENTION_DAYS - elapsedDays);
+  };
+
+  const handleRestore = async (book: TrashedBook) => {
+    try {
+      await restoreBook(book.id);
+      toast.success(`已恢复《${book.title}》`);
+      await loadTrashedBooks();
+      await refreshBooks();
+    } catch (error) {
+      console.error("恢复书籍失败:", error);
+      toast.error("恢复书籍失败");
+    }
+  };
+
+  const handlePurge = async (book: TrashedBook) => {
+    try {
+      const confirmed = await ask(
+        `确定要彻底删除《${book.title}》吗？\n\n书籍文件和全部数据（阅读进度、笔记、对话）将被永久移除，此操作无法撤销。`,
+        { title: "彻底删除", kind: "warning" },
+      );
+      if (!confirmed) return;
+
+      await purgeBook(book.id);
+      toast.success("已彻底删除");
+      await loadTrashedBooks();
+    } catch (error) {
+      console.error("彻底删除书籍失败:", error);
+      toast.error("彻底删除书籍失败");
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex shrink-0 items-center justify-between px-3 pt-3">
+        <h3 className="font-bold text-3xl dark:border-neutral-700">回收站</h3>
+        <span className="text-neutral-500 text-xs dark:text-neutral-500">
+          删除的书籍保留 {RETENTION_DAYS} 天后自动彻底清除
+        </span>
+      </div>
+
+      {isLoading ? (
+        <div className="flex flex-1 items-center justify-center">
+          <div className="text-neutral-600 dark:text-neutral-400">加载中...</div>
+        </div>
+      ) : trashedBooks.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center">
+          <div className="text-center">
+            <div className="mx-auto mb-3 w-fit rounded-full bg-neutral-100 p-3 dark:bg-neutral-800">
+              <Trash2 size={24} className="text-neutral-500 dark:text-neutral-500" />
+            </div>
+            <p className="text-neutral-600 text-sm dark:text-neutral-400">回收站是空的</p>
+            <p className="mt-1 text-neutral-500 text-xs dark:text-neutral-500">
+              删除的书籍会在这里保留 {RETENTION_DAYS} 天，期间可随时恢复
+            </p>
+          </div>
+        </div>
+      ) : (
+        <div className="flex-1 overflow-y-auto p-3 pb-8">
+          <div className="space-y-2">
+            {trashedBooks.map((book) => (
+              <div key={book.id} className="flex items-center gap-3 rounded-lg border p-3">
+                {book.coverUrl ? (
+                  <img src={book.coverUrl} alt={book.title} className="h-16 w-12 flex-shrink-0 rounded object-cover" />
+                ) : (
+                  <div className="flex h-16 w-12 flex-shrink-0 items-center justify-center rounded bg-neutral-100 dark:bg-neutral-800">
+                    <span className="text-lg text-neutral-400">📖</span>
+                  </div>
+                )}
+                <div className="min-w-0 flex-1">
+                  <h4 className="line-clamp-1 font-medium text-neutral-900 text-sm dark:text-neutral-100">
+                    {book.title}
+                  </h4>
+                  <p className="line-clamp-1 text-neutral-600 text-xs dark:text-neutral-400">
+                    {book.author || "未知作者"}
+                  </p>
+                  <p className="mt-1 text-neutral-500 text-xs dark:text-neutral-500">
+                    删除于 {dayjs(book.trashedAt).format("YYYY-MM-DD HH:mm")} · 剩余 {remainingDays(book.trashedAt)} 天
+                  </p>
+                </div>
+                <div className="flex flex-shrink-0 items-center gap-2">
+                  <Button size="sm" variant="outline" onClick={() => handleRestore(book)}>
+                    恢复
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={() => handlePurge(book)}>
+                    彻底删除
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/services/book-service.ts
+++ b/packages/app/src/services/book-service.ts
@@ -182,6 +182,37 @@ export async function deleteBook(id: string): Promise<void> {
   }
 }
 
+/** 从回收站恢复书籍 */
+export async function restoreBook(id: string): Promise<void> {
+  try {
+    await invoke("restore_book", { id });
+  } catch (error) {
+    console.error("恢复书籍失败:", error);
+    throw new Error(`恢复书籍失败: ${error instanceof Error ? error.message : "未知错误"}`);
+  }
+}
+
+/** 回收站列表（按删除时间倒序） */
+export async function getTrashedBooks(): Promise<SimpleBook[]> {
+  try {
+    const result = await invoke<SimpleBook[]>("get_trashed_books");
+    return result;
+  } catch (error) {
+    console.error("获取回收站失败:", error);
+    throw new Error(`获取回收站失败: ${error instanceof Error ? error.message : "未知错误"}`);
+  }
+}
+
+/** 彻底删除（删磁盘文件与全部关联数据，不可恢复） */
+export async function purgeBook(id: string): Promise<void> {
+  try {
+    await invoke("purge_book", { id });
+  } catch (error) {
+    console.error("彻底删除书籍失败:", error);
+    throw new Error(`彻底删除书籍失败: ${error instanceof Error ? error.message : "未知错误"}`);
+  }
+}
+
 export async function searchBooks(
   query: string,
   options: Omit<BookQueryOptions, "searchQuery"> = {},

--- a/packages/app/src/types/simple-book.ts
+++ b/packages/app/src/types/simple-book.ts
@@ -11,6 +11,9 @@ export interface SimpleBook {
 
   tags?: string[];
 
+  /** 回收站软删除时间戳（毫秒），null/undefined = 未删除 */
+  trashedAt?: number | null;
+
   createdAt: number;
   updatedAt: number;
 }


### PR DESCRIPTION
## 概述

把"删除书籍"从不可恢复的硬删改为回收站模式：

- `books` 表新增 `trashed_at` 软删除时间戳（毫秒，可空），经 `database.rs` 的幂等迁移通道添加（不动 `schema.sql`，方便跟上游同步）
- 删除书籍 → 进回收站；保留期内可恢复；超期彻底删除
- 新增回收站页面（`pages/library/trash.tsx`）、侧栏入口与书库布局集成、`book-service` 相应 API

## 与 #44 的关系

两个 PR 都会引入 `run_migrations` 迁移通道这个函数（#44 加 `threads.starred` 列，本 PR 加 `books.trashed_at` 列）——**先合任何一个，另一个 rebase 时在函数里保留两段 ALTER 即可**，冲突点已知且只有这一处。

## 验证

`cargo check` 通过、`tsc --noEmit` 通过